### PR TITLE
feat: add scan appearance and measured PDF sizes

### DIFF
--- a/app/src/main/java/com/majkeylab/scanit/AndroidScanPdf.kt
+++ b/app/src/main/java/com/majkeylab/scanit/AndroidScanPdf.kt
@@ -1,0 +1,129 @@
+package com.majkeylab.scanit
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.CancellationException
+
+internal fun buildScanPdfFromPages(
+    output: File,
+    sourcePages: List<File>,
+    renderedPages: List<File>,
+    appearance: ScanAppearance,
+    target: PdfSizeTarget,
+    isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+): ScanPdfBuildResult {
+    require(sourcePages.isNotEmpty() && sourcePages.size == renderedPages.size) {
+        "PDF source and rendered pages must be complete"
+    }
+    require(sourcePages.size <= MAX_SCAN_PAGES) {
+        "PDF page count exceeds $MAX_SCAN_PAGES"
+    }
+    val pages =
+        sourcePages.indices.map { index ->
+            throwIfAndroidPdfCancelled(isCancelled)
+            val source = sourcePages[index]
+            val rendered = renderedPages[index]
+            val sourceBounds = readJpegDimensions(source)
+            throwIfAndroidPdfCancelled(isCancelled)
+            val renderedBounds = readJpegDimensions(rendered)
+            val baseSample = appearanceDecodeSampleSize(sourceBounds.width, sourceBounds.height)
+            ScanPdfBuildPage(
+                longestEdge = maxOf(renderedBounds.width, renderedBounds.height),
+                renderJpeg = { workingDirectory, sampleMultiplier ->
+                    if (sampleMultiplier == 1) {
+                        JpegPdfPage(rendered, renderedBounds.width, renderedBounds.height)
+                    } else {
+                        val destination = File(workingDirectory, "page-${index + 1}.jpg")
+                        val result =
+                            ScanAppearanceRenderer.renderJpeg(
+                                source = source,
+                                destination = destination,
+                                appearance = appearance,
+                                minimumSampleSize =
+                                    relativePdfSourceSampleSize(baseSample, sampleMultiplier),
+                                isCancelled = isCancelled,
+                            )
+                        JpegPdfPage(
+                            destination,
+                            result.width,
+                            result.height,
+                            physicalWidthPixels = renderedBounds.width,
+                            physicalHeightPixels = renderedBounds.height,
+                        )
+                    }
+                },
+                createBitonal = { page -> lazyBitonalPdfPage(page, isCancelled) },
+            )
+        }
+    return buildScanPdf(output, pages, target, isBitonalPdfEligible(appearance), isCancelled)
+}
+
+internal fun readJpegDimensions(file: File): JpegDimensions {
+    if (!file.isFile || file.length() <= 0L) throw IOException("JPEG page is missing or empty")
+    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(file.path, options)
+    if (
+        options.outWidth <= 0 ||
+            options.outHeight <= 0 ||
+            !options.outMimeType.equals(SCAN_JPEG_MIME_TYPE, ignoreCase = true)
+    ) {
+        throw IOException("Scan page is not a readable JPEG")
+    }
+    return JpegDimensions(options.outWidth, options.outHeight)
+}
+
+internal data class JpegDimensions(val width: Int, val height: Int)
+
+private fun lazyBitonalPdfPage(
+    page: JpegPdfPage,
+    isCancelled: () -> Boolean,
+): BitonalPdfPage {
+    var bitmap: Bitmap? = null
+    var argb: IntArray? = null
+    return BitonalPdfPage(
+        width = page.width,
+        height = page.height,
+        physicalWidthPixels = page.physicalWidthPixels,
+        physicalHeightPixels = page.physicalHeightPixels,
+        onComplete = {
+            bitmap?.recycle()
+            bitmap = null
+            argb = null
+        },
+        readRow = { row, grayscale ->
+            throwIfAndroidPdfCancelled(isCancelled)
+            val decoded =
+                bitmap ?: decodeBitonalSource(page).also { opened -> bitmap = opened }
+            val pixels = argb ?: IntArray(page.width).also { rowPixels -> argb = rowPixels }
+            decoded.getPixels(pixels, 0, page.width, 0, row, page.width, 1)
+            pixels.indices.forEach { x ->
+                grayscale[x] = if (argbLuma(pixels[x]) <= BITONAL_THRESHOLD) 0 else 1
+            }
+        },
+    )
+}
+
+private fun decodeBitonalSource(page: JpegPdfPage): Bitmap {
+    val bitmap =
+        BitmapFactory.decodeFile(
+            page.file.path,
+            BitmapFactory.Options().apply {
+                inPreferredConfig = Bitmap.Config.RGB_565
+                inScaled = false
+            },
+        ) ?: throw IOException("Rendered JPEG could not be decoded for the bitonal PDF")
+    if (bitmap.width != page.width || bitmap.height != page.height) {
+        bitmap.recycle()
+        throw IOException("Rendered JPEG dimensions changed during PDF creation")
+    }
+    return bitmap
+}
+
+private fun throwIfAndroidPdfCancelled(isCancelled: () -> Boolean) {
+    if (isCancelled()) throw CancellationException("PDF build cancelled")
+}
+
+private const val SCAN_JPEG_MIME_TYPE = "image/jpeg"
+private const val BITONAL_THRESHOLD = 127

--- a/app/src/main/java/com/majkeylab/scanit/AppUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/AppUi.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -85,6 +86,7 @@ import java.io.File
 import java.io.IOException
 import java.text.DateFormat
 import java.util.Date
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
 
 internal enum class AppLanguage(val languageTag: String?) {
@@ -139,7 +141,7 @@ internal fun ScanItApp(
     language: AppLanguage,
     defaultEmailSubjects: Set<String>,
     onScan: () -> Unit,
-    onSaveSettings: (AppSettings) -> Unit,
+    onSaveSettings: (AppSettings) -> Boolean,
     onLanguageChange: (AppLanguage) -> Unit,
     onPdfFolderSelected: (Uri, Int) -> UiMessage?,
     onPdfFolderCleared: () -> UiMessage?,
@@ -154,15 +156,24 @@ internal fun ScanItApp(
     onShareImages: (() -> Unit)? = null,
     onPrint: (() -> Unit)? = null,
     onSaveNow: (SaveNowTarget) -> Unit = {},
+    onApplyAppearance: (ScanAppearanceSettings) -> Unit = {},
 ) {
     var showSettings by rememberSaveable { mutableStateOf(false) }
     val resultCacheId = (state as? ScreenState.Result)?.scan?.cached?.baseName
     var fileDetailsExpanded by rememberSaveable(resultCacheId) { mutableStateOf(false) }
-    val backAction = appBackAction(showSettings, fileDetailsExpanded, state)
+    var appearanceEditorExpanded by rememberSaveable(resultCacheId) { mutableStateOf(false) }
+    val backAction =
+        appBackAction(
+            showSettings,
+            fileDetailsExpanded,
+            state,
+            appearanceOpen = appearanceEditorExpanded,
+        )
     BackHandler {
         when (backAction) {
             AppBackAction.CloseSettings -> showSettings = false
             AppBackAction.CollapseFileDetails -> fileDetailsExpanded = false
+            AppBackAction.CollapseAppearance -> appearanceEditorExpanded = false
             AppBackAction.ShowRecent -> onNavigateBack()
             AppBackAction.LaunchScanner -> onScan()
             AppBackAction.Consume -> Unit
@@ -194,7 +205,11 @@ internal fun ScanItApp(
                         message = state.message.resolve(),
                         onRetry = onScan,
                         onRecent = onRecent,
-                        onSettings = { showSettings = true },
+                        onSettings = {
+                            appearanceEditorExpanded = false
+                            fileDetailsExpanded = false
+                            showSettings = true
+                        },
                     )
                 is ScreenState.Recent ->
                     RecentScreen(
@@ -211,15 +226,29 @@ internal fun ScanItApp(
                         result = state,
                         onNewScan = onScan,
                         onRecent = onRecent,
-                        onSettings = { showSettings = true },
+                        onSettings = {
+                            appearanceEditorExpanded = false
+                            fileDetailsExpanded = false
+                            showSettings = true
+                        },
                         onSharePdf = onSharePdf,
                         onShareImages = onShareImages,
                         onPrint = onPrint,
                         fileDetailsExpanded = fileDetailsExpanded,
-                        onFileDetailsChange = { fileDetailsExpanded = it },
+                        onFileDetailsChange = { expanded ->
+                            fileDetailsExpanded = expanded
+                            if (expanded) appearanceEditorExpanded = false
+                        },
                         onSaveNow = onSaveNow,
                         onSelectPage = onSelectResultPage,
                         onLoadThumbnail = onLoadThumbnail,
+                        defaultAppearance = settings.appearance,
+                        appearanceEditorExpanded = appearanceEditorExpanded,
+                        onAppearanceEditorChange = { expanded ->
+                            appearanceEditorExpanded = expanded
+                            if (expanded) fileDetailsExpanded = false
+                        },
+                        onApplyAppearance = onApplyAppearance,
                     )
             }
         }
@@ -277,6 +306,10 @@ private fun ResultScreen(
     onSaveNow: (SaveNowTarget) -> Unit,
     onSelectPage: (Int) -> Unit,
     onLoadThumbnail: suspend (File) -> Bitmap?,
+    defaultAppearance: ScanAppearanceSettings,
+    appearanceEditorExpanded: Boolean,
+    onAppearanceEditorChange: (Boolean) -> Unit,
+    onApplyAppearance: (ScanAppearanceSettings) -> Unit,
 ) {
     val scan = result.scan
     val pageCount = scan.cached.pages.size
@@ -285,6 +318,26 @@ private fun ResultScreen(
         stringResource(R.string.page_position, selectedPageIndex + 1, pageCount)
     val saveTargets = saveNowTargets(scan)
     var showSaveDialog by rememberSaveable(scan.cached.entryId) { mutableStateOf(false) }
+    val appliedAppearance = scan.cached.appearance
+    val initialAppearance =
+        appliedAppearance?.let(defaultAppearance::withApplied) ?: defaultAppearance
+    var appearanceMode by rememberSaveable(scan.cached.entryId, appearanceEditorExpanded) {
+        mutableStateOf(initialAppearance.colorMode.wireValue)
+    }
+    var colorIntensity by rememberSaveable(scan.cached.entryId, appearanceEditorExpanded) {
+        mutableStateOf(initialAppearance.colorIntensity)
+    }
+    var grayscaleIntensity by rememberSaveable(scan.cached.entryId, appearanceEditorExpanded) {
+        mutableStateOf(initialAppearance.grayscaleIntensity)
+    }
+    var blackWhiteIntensity by rememberSaveable(scan.cached.entryId, appearanceEditorExpanded) {
+        mutableStateOf(initialAppearance.blackWhiteIntensity)
+    }
+    var shadows by rememberSaveable(scan.cached.entryId, appearanceEditorExpanded) {
+        mutableStateOf(initialAppearance.shadows)
+    }
+    val actionsEnabled = !result.outputSaveInProgress && !result.appearanceApplyInProgress
+    val appearanceActionsEnabled = actionsEnabled && !result.pagePreviewLoading
     Scaffold(
         contentWindowInsets = WindowInsets.safeDrawing,
         topBar = {
@@ -292,7 +345,7 @@ private fun ResultScreen(
                 title = "",
                 onRecent = onRecent,
                 onSettings = onSettings,
-                actionsEnabled = !result.outputSaveInProgress,
+                actionsEnabled = actionsEnabled,
             )
         },
     ) { padding ->
@@ -339,16 +392,112 @@ private fun ResultScreen(
                     ResultPageStrip(
                         pages = scan.cached.pages,
                         selectedPageIndex = selectedPageIndex,
-                        enabled = !result.outputSaveInProgress,
+                        enabled = actionsEnabled,
                         onSelectPage = onSelectPage,
                         onLoadThumbnail = onLoadThumbnail,
                     )
                 }
             }
+            if (
+                appliedAppearance != null &&
+                    scan.cached.sourcePages.size == scan.cached.pages.size &&
+                    scan.cached.entryId != null &&
+                    scan.outputMetadataValid
+            ) {
+                item {
+                    OutlinedButton(
+                        onClick = { onAppearanceEditorChange(!appearanceEditorExpanded) },
+                        enabled = appearanceActionsEnabled,
+                        modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
+                    ) {
+                        Text(stringResource(R.string.edit_appearance))
+                    }
+                    if (appearanceEditorExpanded) {
+                        val selectedMode =
+                            ScanColorMode.entries.firstOrNull { it.wireValue == appearanceMode }
+                                ?: ScanColorMode.BlackWhite
+                        AppearanceControls(
+                            colorMode = selectedMode,
+                            filterIntensity =
+                                when (selectedMode) {
+                                    ScanColorMode.Color -> colorIntensity
+                                    ScanColorMode.Grayscale -> grayscaleIntensity
+                                    ScanColorMode.BlackWhite -> blackWhiteIntensity
+                                },
+                            shadows = shadows,
+                            onColorModeChange = { appearanceMode = it.wireValue },
+                            onFilterIntensityChange = { value ->
+                                when (selectedMode) {
+                                    ScanColorMode.Color -> colorIntensity = value
+                                    ScanColorMode.Grayscale -> grayscaleIntensity = value
+                                    ScanColorMode.BlackWhite -> blackWhiteIntensity = value
+                                }
+                            },
+                            onShadowsChange = { shadows = it },
+                            enabled = appearanceActionsEnabled,
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            OutlinedButton(
+                                onClick = { onAppearanceEditorChange(false) },
+                                enabled = !result.appearanceApplyInProgress,
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Text(stringResource(R.string.cancel))
+                            }
+                            Button(
+                                onClick = {
+                                    onApplyAppearance(
+                                        parseScanAppearanceSettings(
+                                            colorModeWireValue = appearanceMode,
+                                            colorIntensity = colorIntensity,
+                                            grayscaleIntensity = grayscaleIntensity,
+                                            blackWhiteIntensity = blackWhiteIntensity,
+                                            shadows = shadows,
+                                        ),
+                                    )
+                                },
+                                enabled = appearanceActionsEnabled,
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Text(
+                                    stringResource(
+                                        if (result.appearanceApplyInProgress) {
+                                            R.string.applying_appearance
+                                        } else {
+                                            R.string.apply_appearance
+                                        },
+                                    ),
+                                )
+                            }
+                        }
+                        if (result.appearanceApplyInProgress) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                            }
+                        }
+                    }
+                    result.appearanceMessage?.let { message ->
+                        Text(
+                            message.resolve(),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.semantics {
+                                liveRegion = LiveRegionMode.Polite
+                            },
+                        )
+                    }
+                }
+            }
             item {
                 Button(
                     onClick = { onSharePdf?.invoke() },
-                    enabled = onSharePdf != null && !result.outputSaveInProgress,
+                    enabled = onSharePdf != null && actionsEnabled,
                     modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
                 ) {
                     Text(stringResource(R.string.send_pdf))
@@ -357,7 +506,7 @@ private fun ResultScreen(
             item {
                 OutlinedButton(
                     onClick = { onShareImages?.invoke() },
-                    enabled = onShareImages != null && !result.outputSaveInProgress,
+                    enabled = onShareImages != null && actionsEnabled,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(stringResource(R.string.send_images))
@@ -366,7 +515,7 @@ private fun ResultScreen(
             item {
                 OutlinedButton(
                     onClick = { onPrint?.invoke() },
-                    enabled = onPrint != null && !result.outputSaveInProgress,
+                    enabled = onPrint != null && actionsEnabled,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(stringResource(R.string.print_document))
@@ -375,7 +524,7 @@ private fun ResultScreen(
             item {
                 Button(
                     onClick = onNewScan,
-                    enabled = !result.outputSaveInProgress,
+                    enabled = actionsEnabled,
                     modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
                 ) {
                     Text(stringResource(R.string.new_scan))
@@ -384,6 +533,7 @@ private fun ResultScreen(
             item {
                 TextButton(
                     onClick = { onFileDetailsChange(!fileDetailsExpanded) },
+                    enabled = actionsEnabled,
                     modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
                 ) {
                     Text(stringResource(R.string.file_details), modifier = Modifier.weight(1f))
@@ -527,6 +677,22 @@ private fun FileDetails(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        if (scan.warnings.isNotEmpty()) {
+            Column(
+                modifier = Modifier.fillMaxWidth().semantics {
+                    liveRegion = LiveRegionMode.Polite
+                },
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                scan.warnings.forEach { warning ->
+                    Text(
+                        warning.resolve(),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
         val savedPdf = scan.savedPdf
         Text(
             when {
@@ -563,13 +729,6 @@ private fun FileDetails(
                     ),
                 )
             }
-        }
-        scan.warnings.forEach {
-            Text(
-                it.resolve(),
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
-            )
         }
     }
 }
@@ -969,7 +1128,7 @@ private fun SettingsScreen(
     language: AppLanguage,
     defaultEmailSubjects: Set<String>,
     onClose: () -> Unit,
-    onSave: (AppSettings) -> Unit,
+    onSave: (AppSettings) -> Boolean,
     onLanguageChange: (AppLanguage) -> Unit,
     onPdfFolderSelected: (Uri, Int) -> UiMessage?,
     onPdfFolderCleared: () -> UiMessage?,
@@ -990,6 +1149,22 @@ private fun SettingsScreen(
         mutableStateOf(settings.deleteImagesAfterShare)
     }
     var pdfTreeUri by rememberSaveable { mutableStateOf(settings.pdfTreeUri) }
+    var appearanceMode by rememberSaveable {
+        mutableStateOf(settings.appearance.colorMode.wireValue)
+    }
+    var colorIntensity by rememberSaveable {
+        mutableStateOf(settings.appearance.colorIntensity)
+    }
+    var grayscaleIntensity by rememberSaveable {
+        mutableStateOf(settings.appearance.grayscaleIntensity)
+    }
+    var blackWhiteIntensity by rememberSaveable {
+        mutableStateOf(settings.appearance.blackWhiteIntensity)
+    }
+    var shadows by rememberSaveable { mutableStateOf(settings.appearance.shadows) }
+    var pdfSizeTargetWire by rememberSaveable {
+        mutableStateOf(settings.pdfSizeTarget.wireValue)
+    }
     var folderError by remember { mutableStateOf<UiMessage?>(null) }
     var settingsError by remember { mutableStateOf<UiMessage?>(null) }
     val uriHandler = LocalUriHandler.current
@@ -1068,6 +1243,53 @@ private fun SettingsScreen(
                 }
             }
             item { HorizontalDivider() }
+            item { SectionTitle(stringResource(R.string.default_appearance)) }
+            item {
+                val selectedMode =
+                    ScanColorMode.entries.firstOrNull { it.wireValue == appearanceMode }
+                        ?: ScanColorMode.BlackWhite
+                AppearanceControls(
+                    colorMode = selectedMode,
+                    filterIntensity =
+                        when (selectedMode) {
+                            ScanColorMode.Color -> colorIntensity
+                            ScanColorMode.Grayscale -> grayscaleIntensity
+                            ScanColorMode.BlackWhite -> blackWhiteIntensity
+                        },
+                    shadows = shadows,
+                    onColorModeChange = { appearanceMode = it.wireValue },
+                    onFilterIntensityChange = { value ->
+                        when (selectedMode) {
+                            ScanColorMode.Color -> colorIntensity = value
+                            ScanColorMode.Grayscale -> grayscaleIntensity = value
+                            ScanColorMode.BlackWhite -> blackWhiteIntensity = value
+                        }
+                    },
+                    onShadowsChange = { shadows = it },
+                )
+            }
+            item { SectionTitle(stringResource(R.string.pdf_size)) }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    items(PdfSizeTarget.entries) { target ->
+                        FilterChip(
+                            selected = target.wireValue == pdfSizeTargetWire,
+                            onClick = { pdfSizeTargetWire = target.wireValue },
+                            label = { Text(pdfSizeTargetLabel(target)) },
+                        )
+                    }
+                }
+            }
+            item {
+                Text(
+                    stringResource(R.string.pdf_size_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            item { HorizontalDivider() }
             item { SectionTitle(stringResource(R.string.saving)) }
             item {
                 SettingsSwitch(
@@ -1081,6 +1303,13 @@ private fun SettingsScreen(
                     label = stringResource(R.string.save_images),
                     checked = saveImages,
                     onCheckedChange = { saveImages = it },
+                )
+            }
+            item {
+                Text(
+                    stringResource(R.string.automatic_saving_scope),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             item {
@@ -1198,21 +1427,35 @@ private fun SettingsScreen(
                 Button(
                     onClick = {
                         try {
-                            onSave(
-                                AppSettings(
-                                    savePdf = savePdf,
-                                    saveImages = saveImages,
-                                    albumName = albumName,
-                                    multipage = multipage,
-                                    allowGallery = allowGallery,
-                                    emailSubject = emailSubject,
-                                    emailBody = emailBody,
-                                    pdfTreeUri = pdfTreeUri,
-                                    deletePdfAfterShare = deletePdfAfterShare,
-                                    deleteImagesAfterShare = deleteImagesAfterShare,
-                                ),
-                            )
-                            onClose()
+                            val saved =
+                                onSave(
+                                    AppSettings(
+                                        savePdf = savePdf,
+                                        saveImages = saveImages,
+                                        albumName = albumName,
+                                        multipage = multipage,
+                                        allowGallery = allowGallery,
+                                        emailSubject = emailSubject,
+                                        emailBody = emailBody,
+                                        pdfTreeUri = pdfTreeUri,
+                                        deletePdfAfterShare = deletePdfAfterShare,
+                                        deleteImagesAfterShare = deleteImagesAfterShare,
+                                        appearance =
+                                            parseScanAppearanceSettings(
+                                                colorModeWireValue = appearanceMode,
+                                                colorIntensity = colorIntensity,
+                                                grayscaleIntensity = grayscaleIntensity,
+                                                blackWhiteIntensity = blackWhiteIntensity,
+                                                shadows = shadows,
+                                            ),
+                                        pdfSizeTarget = parsePdfSizeTarget(pdfSizeTargetWire),
+                                    ),
+                                )
+                            if (saved) {
+                                onClose()
+                            } else {
+                                settingsError = settingsSaveFailed
+                            }
                         } catch (_: RuntimeException) {
                             settingsError = settingsSaveFailed
                         }
@@ -1241,6 +1484,72 @@ private fun SettingsScreen(
         }
     }
 }
+
+@Composable
+private fun AppearanceControls(
+    colorMode: ScanColorMode,
+    filterIntensity: Int,
+    shadows: Int,
+    onColorModeChange: (ScanColorMode) -> Unit,
+    onFilterIntensityChange: (Int) -> Unit,
+    onShadowsChange: (Int) -> Unit,
+    enabled: Boolean = true,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            items(ScanColorMode.entries) { mode ->
+                FilterChip(
+                    selected = mode == colorMode,
+                    onClick = { onColorModeChange(mode) },
+                    enabled = enabled,
+                    label = { Text(scanColorModeLabel(mode)) },
+                )
+            }
+        }
+        val filterIntensityText =
+            stringResource(R.string.filter_intensity_percent, filterIntensity)
+        Text(filterIntensityText)
+        Slider(
+            value = clampAppearancePercent(filterIntensity).toFloat(),
+            onValueChange = { onFilterIntensityChange(it.roundToInt()) },
+            valueRange = 0f..100f,
+            enabled = enabled,
+            modifier = Modifier.semantics { contentDescription = filterIntensityText },
+        )
+        val shadowsText = stringResource(R.string.shadows_percent, shadows)
+        Text(shadowsText)
+        Slider(
+            value = clampAppearancePercent(shadows).toFloat(),
+            onValueChange = { onShadowsChange(it.roundToInt()) },
+            valueRange = 0f..100f,
+            enabled = enabled,
+            modifier = Modifier.semantics { contentDescription = shadowsText },
+        )
+    }
+}
+
+@Composable
+private fun scanColorModeLabel(mode: ScanColorMode): String =
+    stringResource(
+        when (mode) {
+            ScanColorMode.Color -> R.string.filter_color
+            ScanColorMode.Grayscale -> R.string.filter_grayscale
+            ScanColorMode.BlackWhite -> R.string.filter_black_white
+        },
+    )
+
+@Composable
+private fun pdfSizeTargetLabel(target: PdfSizeTarget): String =
+    stringResource(
+        when (target) {
+            PdfSizeTarget.Original -> R.string.pdf_size_original
+            PdfSizeTarget.Mb5 -> R.string.pdf_size_5_mb
+            PdfSizeTarget.Mb10 -> R.string.pdf_size_10_mb
+            PdfSizeTarget.Mb20 -> R.string.pdf_size_20_mb
+        },
+    )
 
 @Composable
 private fun SettingsSwitch(

--- a/app/src/main/java/com/majkeylab/scanit/BitonalPdfWriter.kt
+++ b/app/src/main/java/com/majkeylab/scanit/BitonalPdfWriter.kt
@@ -7,6 +7,7 @@ import java.io.FilterOutputStream
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.util.concurrent.CancellationException
 import java.util.zip.Deflater
 import java.util.zip.DeflaterOutputStream
 
@@ -14,12 +15,20 @@ import java.util.zip.DeflaterOutputStream
 internal class BitonalPdfPage(
     val width: Int,
     val height: Int,
+    val physicalWidthPixels: Int = width,
+    val physicalHeightPixels: Int = height,
+    internal val onComplete: () -> Unit = {},
     internal val readRow: (row: Int, grayscale: ByteArray) -> Unit,
 )
 
 internal object BitonalPdfWriter {
-    fun write(output: File, pages: List<BitonalPdfPage>) {
+    fun write(
+        output: File,
+        pages: List<BitonalPdfPage>,
+        isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+    ) {
         validatePages(pages)
+        throwIfBitonalPdfCancelled(isCancelled)
         val target = output.absoluteFile
         val parent = requireNotNull(target.parentFile) { "PDF destination must have a parent" }
         require(parent.isDirectory) { "PDF destination directory does not exist" }
@@ -28,9 +37,10 @@ internal object BitonalPdfWriter {
         var failure: Throwable? = null
         try {
             BufferedOutputStream(FileOutputStream(staging.toFile())).use { stream ->
-                writePdf(PdfOutput(stream), pages)
+                writePdf(PdfOutput(stream), pages, isCancelled)
             }
-            Files.createLink(target.toPath(), staging)
+            throwIfBitonalPdfCancelled(isCancelled)
+            publishStagedFileNoReplace(staging, target.toPath())
         } catch (throwable: Throwable) {
             failure = throwable
             throw throwable
@@ -43,7 +53,11 @@ internal object BitonalPdfWriter {
         }
     }
 
-    private fun writePdf(output: PdfOutput, pages: List<BitonalPdfPage>) {
+    private fun writePdf(
+        output: PdfOutput,
+        pages: List<BitonalPdfPage>,
+        isCancelled: () -> Boolean,
+    ) {
         val objectCount = bitonalPdfObjectCount(pages.size)
         val offsets = LongArray(Math.addExact(objectCount, 1))
         output.ascii("%PDF-1.4\n")
@@ -59,7 +73,8 @@ internal object BitonalPdfWriter {
         output.ascii("<< /Type /Pages /Kids [$kids] /Count ${pages.size} >>\nendobj\n")
 
         pages.forEachIndexed { index, page ->
-            writePage(output, offsets, index, page)
+            throwIfBitonalPdfCancelled(isCancelled)
+            writePage(output, offsets, index, page, isCancelled)
         }
 
         val xrefOffset = output.bytesWritten
@@ -79,16 +94,19 @@ internal object BitonalPdfWriter {
         offsets: LongArray,
         index: Int,
         page: BitonalPdfPage,
+        isCancelled: () -> Boolean,
     ) {
         val pageObject = pageObject(index)
         val imageObject = pageObject + 1
         val imageLengthObject = pageObject + 2
         val contentObject = pageObject + 3
         val contentLengthObject = pageObject + 4
+        val pageWidth = pdfPointsAt300Dpi(page.physicalWidthPixels)
+        val pageHeight = pdfPointsAt300Dpi(page.physicalHeightPixels)
 
         output.objectStart(pageObject, offsets)
         output.ascii(
-            "<< /Type /Page /Parent $PAGES_OBJECT 0 R /MediaBox [0 0 ${page.width} ${page.height}] " +
+            "<< /Type /Page /Parent $PAGES_OBJECT 0 R /MediaBox [0 0 $pageWidth $pageHeight] " +
                 "/Resources << /XObject << /Im0 $imageObject 0 R >> >> " +
                 "/Contents $contentObject 0 R >>\nendobj\n",
         )
@@ -100,7 +118,7 @@ internal object BitonalPdfWriter {
                 "/Length $imageLengthObject 0 R >>\nstream\n",
         )
         val imageStart = output.bytesWritten
-        writeCompressedRows(output, page)
+        writeCompressedRows(output, page, isCancelled)
         val imageLength = output.bytesWritten - imageStart
         output.ascii("\nendstream\nendobj\n")
         output.numberObject(imageLengthObject, imageLength, offsets)
@@ -108,28 +126,42 @@ internal object BitonalPdfWriter {
         output.objectStart(contentObject, offsets)
         output.ascii("<< /Length $contentLengthObject 0 R >>\nstream\n")
         val contentStart = output.bytesWritten
-        output.ascii("q\n${page.width} 0 0 ${page.height} 0 0 cm\n/Im0 Do\nQ\n")
+        output.ascii("q\n$pageWidth 0 0 $pageHeight 0 0 cm\n/Im0 Do\nQ\n")
         val contentLength = output.bytesWritten - contentStart
         output.ascii("endstream\nendobj\n")
         output.numberObject(contentLengthObject, contentLength, offsets)
     }
 
-    private fun writeCompressedRows(output: OutputStream, page: BitonalPdfPage) {
+    private fun writeCompressedRows(
+        output: OutputStream,
+        page: BitonalPdfPage,
+        isCancelled: () -> Boolean,
+    ) {
         val grayscale = ByteArray(page.width)
         val packed = ByteArray((page.width.toLong() + 7L).div(8L).toInt())
         val deflater = Deflater(Deflater.BEST_COMPRESSION, false)
         try {
             val compressed = DeflaterOutputStream(output, deflater, COMPRESSION_BUFFER_SIZE)
             repeat(page.height) { row ->
+                throwIfBitonalPdfCancelled(isCancelled)
                 grayscale.fill(WHITE)
                 page.readRow(row, grayscale)
                 packRow(grayscale, packed)
                 compressed.write(packed)
             }
+            throwIfBitonalPdfCancelled(isCancelled)
             compressed.finish()
         } finally {
-            deflater.end()
+            try {
+                deflater.end()
+            } finally {
+                page.onComplete()
+            }
         }
+    }
+
+    private fun throwIfBitonalPdfCancelled(isCancelled: () -> Boolean) {
+        if (isCancelled()) throw CancellationException("PDF build cancelled")
     }
 
     private fun packRow(grayscale: ByteArray, packed: ByteArray) {
@@ -150,18 +182,25 @@ internal object BitonalPdfWriter {
         pages.forEach { page ->
             require(page.width > 0) { "Page width must be positive" }
             require(page.height > 0) { "Page height must be positive" }
+            require(page.physicalWidthPixels > 0 && page.physicalHeightPixels > 0) {
+                "Physical page dimensions must be positive"
+            }
             require(page.width.toLong() * page.height <= MAX_PAGE_PIXELS) {
                 "Page pixel count exceeds $MAX_PAGE_PIXELS"
             }
             require(page.width <= MAX_PAGE_SIDE) { "Page width exceeds $MAX_PAGE_SIDE pixels" }
             require(page.height <= MAX_PAGE_SIDE) { "Page height exceeds $MAX_PAGE_SIDE pixels" }
+            require(
+                page.physicalWidthPixels <= MAX_PAGE_SIDE &&
+                    page.physicalHeightPixels <= MAX_PAGE_SIDE,
+            ) { "Physical page dimensions exceed $MAX_PAGE_SIDE pixels" }
         }
     }
 }
 
 internal fun bitonalPdfObjectCount(pageCount: Int): Int {
     require(pageCount > 0) { "PDF must contain at least one page" }
-    require(pageCount <= MAX_PAGE_COUNT) { "PDF page count exceeds $MAX_PAGE_COUNT" }
+    require(pageCount <= MAX_SCAN_PAGES) { "PDF page count exceeds $MAX_SCAN_PAGES" }
     return BASE_OBJECT_COUNT + pageCount * OBJECTS_PER_PAGE
 }
 
@@ -207,10 +246,6 @@ private const val BASE_OBJECT_COUNT = 2
 private const val FIRST_PAGE_OBJECT = 3
 private const val OBJECTS_PER_PAGE = 5
 private const val COMPRESSION_BUFFER_SIZE = 8192
-private const val OFFSET_TABLE_BUDGET_BYTES = 1024 * 1024
-private const val OFFSET_BYTES = 8
-private const val MAX_PAGE_COUNT =
-    (OFFSET_TABLE_BUDGET_BYTES / OFFSET_BYTES - BASE_OBJECT_COUNT - 1) / OBJECTS_PER_PAGE
-private const val MAX_PAGE_SIDE = 3508
+private const val MAX_PAGE_SIDE = 6_000
 private const val MAX_XREF_OFFSET = 9_999_999_999L
-private val MAX_PAGE_PIXELS = MAX_PAGE_SIDE.toLong() * MAX_PAGE_SIDE
+private const val MAX_PAGE_PIXELS = 12_000_000L

--- a/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
+++ b/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
@@ -137,6 +137,20 @@ internal fun safMissingDocumentStatus(
 ): OutputDeleteStatus =
     if (rootExact && !documentIsChild) OutputDeleteStatus.Absent else OutputDeleteStatus.Failed
 
+internal fun safChildStructureIsValid(
+    sameAuthority: Boolean,
+    rootDocumentId: String,
+    returnedTreeDocumentId: String,
+    returnedDocumentId: String,
+    returnedUriIsCanonical: Boolean,
+): Boolean =
+    sameAuthority &&
+        rootDocumentId.isNotEmpty() &&
+        returnedTreeDocumentId == rootDocumentId &&
+        returnedDocumentId != rootDocumentId &&
+        returnedDocumentId.isNotEmpty() &&
+        returnedUriIsCanonical
+
 internal fun mediaDeleteSelectionArgs(expected: ExpectedMediaItem): Array<String> =
     arrayOf(
         expected.id.toString(),
@@ -360,30 +374,32 @@ internal fun reconcilePdfTreeGrants(
     context: Context,
     current: String?,
     live: Set<String>,
-): Boolean {
-    val resolver = context.contentResolver
-    val permissions = resolver.persistedUriPermissions.filter { DocumentsContract.isTreeUri(it.uri) }
-    val release =
-        pdfTreeGrantsToRelease(
-            persisted = permissions.mapTo(mutableSetOf()) { it.uri.toString() },
-            current = current,
-            live = live,
-        )
-    var releasedAll = true
-    permissions.filter { it.uri.toString() in release }.forEach { permission ->
-        var flags = 0
-        if (permission.isReadPermission) flags = flags or Intent.FLAG_GRANT_READ_URI_PERMISSION
-        if (permission.isWritePermission) flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-        try {
-            if (flags != 0) resolver.releasePersistableUriPermission(permission.uri, flags)
-        } catch (_: SecurityException) {
-            releasedAll = false
-        } catch (_: RuntimeException) {
-            releasedAll = false
+): Boolean =
+    withStorageTransaction {
+        val resolver = context.contentResolver
+        val permissions =
+            resolver.persistedUriPermissions.filter { DocumentsContract.isTreeUri(it.uri) }
+        val release =
+            pdfTreeGrantsToRelease(
+                persisted = permissions.mapTo(mutableSetOf()) { it.uri.toString() },
+                current = current,
+                live = live,
+            )
+        var releasedAll = true
+        permissions.filter { it.uri.toString() in release }.forEach { permission ->
+            var flags = 0
+            if (permission.isReadPermission) flags = flags or Intent.FLAG_GRANT_READ_URI_PERMISSION
+            if (permission.isWritePermission) flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            try {
+                if (flags != 0) resolver.releasePersistableUriPermission(permission.uri, flags)
+            } catch (_: SecurityException) {
+                releasedAll = false
+            } catch (_: RuntimeException) {
+                releasedAll = false
+            }
         }
+        releasedAll
     }
-    return releasedAll
-}
 
 internal class ExactOutputDeleter(private val context: Context) {
     private val resolver = context.contentResolver

--- a/app/src/main/java/com/majkeylab/scanit/JpegPdfWriter.kt
+++ b/app/src/main/java/com/majkeylab/scanit/JpegPdfWriter.kt
@@ -1,0 +1,261 @@
+package com.majkeylab.scanit
+
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FilterOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CancellationException
+
+internal data class JpegPdfPage(
+    val file: File,
+    val width: Int,
+    val height: Int,
+    val physicalWidthPixels: Int = width,
+    val physicalHeightPixels: Int = height,
+)
+
+internal object JpegPdfWriter {
+    fun write(
+        output: File,
+        pages: List<JpegPdfPage>,
+        isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+    ) {
+        validateJpegPages(pages, isCancelled)
+        throwIfJpegPdfCancelled(isCancelled)
+        val target = output.absoluteFile
+        val parent = requireNotNull(target.parentFile) { "PDF destination must have a parent" }
+        require(parent.isDirectory) { "PDF destination directory does not exist" }
+        require(!target.exists()) { "PDF destination already exists" }
+        val staging = Files.createTempFile(parent.toPath(), ".scanit-pdf-", ".part")
+        var failure: Throwable? = null
+        try {
+            BufferedOutputStream(FileOutputStream(staging.toFile())).use { stream ->
+                writeJpegPdf(JpegPdfOutput(stream), pages, isCancelled)
+            }
+            publishStagedFileNoReplace(staging, target.toPath())
+        } catch (throwable: Throwable) {
+            failure = throwable
+            throw throwable
+        } finally {
+            try {
+                Files.deleteIfExists(staging)
+            } catch (cleanupFailure: Throwable) {
+                failure?.addSuppressed(cleanupFailure) ?: throw cleanupFailure
+            }
+        }
+    }
+}
+
+internal fun publishStagedFileNoReplace(
+    staging: Path,
+    target: Path,
+    deleteIfExists: (Path) -> Boolean = Files::deleteIfExists,
+) {
+    var published = false
+    try {
+        Files.createLink(target, staging)
+        published = true
+        deleteIfExists(staging)
+    } catch (failure: Throwable) {
+        if (published) {
+            try {
+                if (
+                    Files.exists(target) &&
+                    (!Files.exists(staging) || Files.isSameFile(target, staging))
+                ) {
+                    deleteIfExists(target)
+                }
+            } catch (rollbackFailure: Throwable) {
+                failure.addSuppressed(rollbackFailure)
+            }
+        }
+        throw failure
+    }
+}
+
+private fun writeJpegPdf(
+    output: JpegPdfOutput,
+    pages: List<JpegPdfPage>,
+    isCancelled: () -> Boolean,
+) {
+    val objectCount = jpegPdfObjectCount(pages.size)
+    val offsets = LongArray(Math.addExact(objectCount, 1))
+    output.ascii("%PDF-1.4\n")
+    output.write(
+        byteArrayOf(
+            '%'.code.toByte(),
+            0xe2.toByte(),
+            0xe3.toByte(),
+            0xcf.toByte(),
+            0xd3.toByte(),
+            '\n'.code.toByte(),
+        ),
+    )
+    output.objectStart(JPEG_CATALOG_OBJECT, offsets)
+    output.ascii("<< /Type /Catalog /Pages $JPEG_PAGES_OBJECT 0 R >>\nendobj\n")
+    output.objectStart(JPEG_PAGES_OBJECT, offsets)
+    val kids = pages.indices.joinToString(" ") { "${jpegPageObject(it)} 0 R" }
+    output.ascii("<< /Type /Pages /Kids [$kids] /Count ${pages.size} >>\nendobj\n")
+    pages.forEachIndexed { index, page ->
+        throwIfJpegPdfCancelled(isCancelled)
+        writeJpegPage(output, offsets, index, page, isCancelled)
+    }
+
+    val xrefOffset = output.bytesWritten
+    output.ascii("xref\n0 ${objectCount + 1}\n")
+    output.ascii("0000000000 65535 f \n")
+    (1..objectCount).forEach { output.ascii(pdfXrefEntry(offsets[it])) }
+    output.ascii(
+        "trailer\n<< /Size ${objectCount + 1} /Root $JPEG_CATALOG_OBJECT 0 R >>\n" +
+            "startxref\n$xrefOffset\n%%EOF\n",
+    )
+}
+
+private fun writeJpegPage(
+    output: JpegPdfOutput,
+    offsets: LongArray,
+    index: Int,
+    page: JpegPdfPage,
+    isCancelled: () -> Boolean,
+) {
+    val pageObject = jpegPageObject(index)
+    val imageObject = pageObject + 1
+    val imageLengthObject = pageObject + 2
+    val contentObject = pageObject + 3
+    val contentLengthObject = pageObject + 4
+    val pageWidth = pdfPointsAt300Dpi(page.physicalWidthPixels)
+    val pageHeight = pdfPointsAt300Dpi(page.physicalHeightPixels)
+    output.objectStart(pageObject, offsets)
+    output.ascii(
+        "<< /Type /Page /Parent $JPEG_PAGES_OBJECT 0 R " +
+            "/MediaBox [0 0 $pageWidth $pageHeight] " +
+            "/Resources << /XObject << /Im0 $imageObject 0 R >> >> " +
+            "/Contents $contentObject 0 R >>\nendobj\n",
+    )
+    output.objectStart(imageObject, offsets)
+    output.ascii(
+        "<< /Type /XObject /Subtype /Image /Width ${page.width} /Height ${page.height} " +
+            "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode " +
+            "/Length $imageLengthObject 0 R >>\nstream\n",
+    )
+    val imageStart = output.bytesWritten
+    val expectedLength = page.file.length()
+    val expectedModified = page.file.lastModified()
+    val copied = copyJpegPage(page.file, output, isCancelled)
+    if (copied != expectedLength || page.file.length() != expectedLength) {
+        throw IOException("JPEG page changed while the PDF was written")
+    }
+    if (page.file.lastModified() != expectedModified) {
+        throw IOException("JPEG page changed while the PDF was written")
+    }
+    val imageLength = output.bytesWritten - imageStart
+    output.ascii("\nendstream\nendobj\n")
+    output.numberObject(imageLengthObject, imageLength, offsets)
+    output.objectStart(contentObject, offsets)
+    output.ascii("<< /Length $contentLengthObject 0 R >>\nstream\n")
+    val contentStart = output.bytesWritten
+    output.ascii("q\n$pageWidth 0 0 $pageHeight 0 0 cm\n/Im0 Do\nQ\n")
+    val contentLength = output.bytesWritten - contentStart
+    output.ascii("endstream\nendobj\n")
+    output.numberObject(contentLengthObject, contentLength, offsets)
+}
+
+private fun copyJpegPage(
+    file: File,
+    output: OutputStream,
+    isCancelled: () -> Boolean,
+): Long {
+    val buffer = ByteArray(JPEG_COPY_BUFFER_SIZE)
+    var copied = 0L
+    file.inputStream().use { input ->
+        while (true) {
+            throwIfJpegPdfCancelled(isCancelled)
+            val count = input.read(buffer)
+            if (count < 0) break
+            output.write(buffer, 0, count)
+            copied += count
+        }
+    }
+    return copied
+}
+
+private fun throwIfJpegPdfCancelled(isCancelled: () -> Boolean) {
+    if (isCancelled()) throw CancellationException("PDF build cancelled")
+}
+
+private fun validateJpegPages(
+    pages: List<JpegPdfPage>,
+    isCancelled: () -> Boolean,
+) {
+    jpegPdfObjectCount(pages.size)
+    pages.forEach { page ->
+        throwIfJpegPdfCancelled(isCancelled)
+        require(page.width > 0 && page.height > 0) { "Page dimensions must be positive" }
+        require(page.physicalWidthPixels > 0 && page.physicalHeightPixels > 0) {
+            "Physical page dimensions must be positive"
+        }
+        require(page.width <= JPEG_MAX_PAGE_SIDE && page.height <= JPEG_MAX_PAGE_SIDE) {
+            "Page dimensions exceed the PDF bound"
+        }
+        require(
+            page.physicalWidthPixels <= JPEG_MAX_PAGE_SIDE &&
+                page.physicalHeightPixels <= JPEG_MAX_PAGE_SIDE,
+        ) { "Physical page dimensions exceed the PDF bound" }
+        require(page.width.toLong() * page.height <= JPEG_MAX_PAGE_PIXELS) {
+            "Page pixel count exceeds the PDF bound"
+        }
+        require(page.file.isFile && page.file.length() > 0L) { "JPEG page is missing or empty" }
+    }
+}
+
+private fun jpegPdfObjectCount(pageCount: Int): Int {
+    require(pageCount > 0) { "PDF must contain at least one page" }
+    require(pageCount <= MAX_SCAN_PAGES) { "PDF page count exceeds $MAX_SCAN_PAGES" }
+    return JPEG_BASE_OBJECT_COUNT + pageCount * JPEG_OBJECTS_PER_PAGE
+}
+
+private fun jpegPageObject(index: Int): Int =
+    JPEG_FIRST_PAGE_OBJECT + index * JPEG_OBJECTS_PER_PAGE
+
+private class JpegPdfOutput(output: OutputStream) : FilterOutputStream(output) {
+    var bytesWritten: Long = 0
+        private set
+
+    override fun write(value: Int) {
+        out.write(value)
+        bytesWritten++
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int) {
+        out.write(bytes, offset, length)
+        bytesWritten += length.toLong()
+    }
+
+    fun ascii(value: String) {
+        write(value.toByteArray(StandardCharsets.US_ASCII))
+    }
+
+    fun objectStart(objectNumber: Int, offsets: LongArray) {
+        offsets[objectNumber] = bytesWritten
+        ascii("$objectNumber 0 obj\n")
+    }
+
+    fun numberObject(objectNumber: Int, value: Long, offsets: LongArray) {
+        objectStart(objectNumber, offsets)
+        ascii("$value\nendobj\n")
+    }
+}
+
+private const val JPEG_CATALOG_OBJECT = 1
+private const val JPEG_PAGES_OBJECT = 2
+private const val JPEG_BASE_OBJECT_COUNT = 2
+private const val JPEG_FIRST_PAGE_OBJECT = 3
+private const val JPEG_OBJECTS_PER_PAGE = 5
+private const val JPEG_COPY_BUFFER_SIZE = 8_192
+private const val JPEG_MAX_PAGE_SIDE = 6_000
+private const val JPEG_MAX_PAGE_PIXELS = 12_000_000L

--- a/app/src/main/java/com/majkeylab/scanit/MainActivity.kt
+++ b/app/src/main/java/com/majkeylab/scanit/MainActivity.kt
@@ -31,7 +31,9 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal fun scannerPageLimit(multipage: Boolean): Int? = if (multipage) null else 1
+internal fun scannerPageLimit(multipage: Boolean): Int = if (multipage) MAX_SCAN_PAGES else 1
+
+internal fun isAcceptedScanPageCount(pageCount: Int): Boolean = pageCount in 1..MAX_SCAN_PAGES
 
 class MainActivity : ComponentActivity() {
     private val viewModel: ScanViewModel by viewModels()
@@ -79,6 +81,7 @@ class MainActivity : ComponentActivity() {
                 onShareImages = ::shareCurrentImages,
                 onPrint = ::printCurrentScan,
                 onSaveNow = viewModel::saveCurrentOutputs,
+                onApplyAppearance = viewModel::applyCurrentAppearance,
             )
         }
         lifecycleScope.launch {
@@ -128,11 +131,9 @@ class MainActivity : ComponentActivity() {
             val optionsBuilder =
                 GmsDocumentScannerOptions.Builder()
                     .setGalleryImportAllowed(settings.allowGallery)
-                    .setResultFormats(
-                        GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
-                        GmsDocumentScannerOptions.RESULT_FORMAT_PDF,
-                    ).setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
-            scannerPageLimit(settings.multipage)?.let(optionsBuilder::setPageLimit)
+                    .setResultFormats(GmsDocumentScannerOptions.RESULT_FORMAT_JPEG)
+                    .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_BASE)
+            optionsBuilder.setPageLimit(scannerPageLimit(settings.multipage))
 
             GmsDocumentScanning.getClient(optionsBuilder.build())
                 .getStartScanIntent(this)
@@ -193,12 +194,7 @@ class MainActivity : ComponentActivity() {
                 viewModel.scannerResultFailed(UiMessage(R.string.scanner_result_error))
                 return
             }
-            val pdf = result.pdf
-            if (pdf == null) {
-                viewModel.scannerResultFailed(UiMessage(R.string.scanner_result_error))
-                return
-            }
-            viewModel.processScan(pages.map { it.imageUri }, pdf.uri)
+            viewModel.processScan(pages.map { it.imageUri })
         } catch (_: RuntimeException) {
             viewModel.scannerResultFailed(UiMessage(R.string.scanner_result_error))
         }

--- a/app/src/main/java/com/majkeylab/scanit/PdfSizePolicy.kt
+++ b/app/src/main/java/com/majkeylab/scanit/PdfSizePolicy.kt
@@ -1,0 +1,102 @@
+package com.majkeylab.scanit
+
+private const val MEGABYTE = 1_000_000L
+private const val MIN_LEGIBLE_PDF_EDGE = 1_280
+
+internal enum class PdfSizeTarget(
+    val wireValue: String,
+    val maxBytes: Long?,
+) {
+    Original("original", null),
+    Mb5("5_mb", 5L * MEGABYTE),
+    Mb10("10_mb", 10L * MEGABYTE),
+    Mb20("20_mb", 20L * MEGABYTE),
+}
+
+internal fun parsePdfSizeTarget(wireValue: String?): PdfSizeTarget =
+    PdfSizeTarget.entries.firstOrNull { it.wireValue == wireValue } ?: PdfSizeTarget.Original
+
+internal enum class PdfEncoding {
+    Jpeg,
+    Bitonal,
+}
+
+internal fun selectPdfEncoding(
+    jpegBytes: Long,
+    bitonalBytes: Long?,
+    bitonalEligible: Boolean,
+): PdfEncoding {
+    require(jpegBytes > 0L && (bitonalBytes == null || bitonalBytes > 0L)) {
+        "PDF candidate sizes must be positive"
+    }
+    return if (bitonalEligible && bitonalBytes != null && bitonalBytes < jpegBytes) {
+        PdfEncoding.Bitonal
+    } else {
+        PdfEncoding.Jpeg
+    }
+}
+
+internal fun pdfSampleMultipliers(
+    longestEdges: List<Int>,
+    minimumEdge: Int = MIN_LEGIBLE_PDF_EDGE,
+): List<Int> {
+    require(longestEdges.isNotEmpty() && longestEdges.all { it > 0 }) {
+        "PDF page edges must be positive"
+    }
+    require(minimumEdge > 0) { "Minimum legible edge must be positive" }
+    val multipliers = mutableListOf(1)
+    var next = 2
+    while (longestEdges.any { it / next >= minimumEdge }) {
+        multipliers += next
+        if (next > Int.MAX_VALUE / 2) break
+        next *= 2
+    }
+    return multipliers
+}
+
+internal fun legiblePdfSampleMultiplier(
+    longestEdge: Int,
+    requestedMultiplier: Int,
+    minimumEdge: Int = MIN_LEGIBLE_PDF_EDGE,
+): Int {
+    require(longestEdge > 0 && minimumEdge > 0) { "PDF page edges must be positive" }
+    require(
+        requestedMultiplier > 0 &&
+            requestedMultiplier and (requestedMultiplier - 1) == 0,
+    ) { "PDF sample multiplier must be a positive power of two" }
+    var selected = requestedMultiplier
+    while (selected > 1 && longestEdge / selected < minimumEdge) {
+        selected /= 2
+    }
+    return selected
+}
+
+internal fun pdfPointsAt300Dpi(pixels: Int): String {
+    require(pixels > 0) { "PDF page dimension must be positive" }
+    val hundredths = Math.multiplyExact(pixels.toLong(), 24L)
+    val whole = hundredths / 100L
+    val fraction = (hundredths % 100L).toInt()
+    return when {
+        fraction == 0 -> whole.toString()
+        fraction % 10 == 0 -> "$whole.${fraction / 10}"
+        else -> "$whole.${fraction.toString().padStart(2, '0')}"
+    }
+}
+
+internal fun isBitonalPdfEligible(appearance: ScanAppearance): Boolean =
+    appearance.colorMode == ScanColorMode.BlackWhite &&
+        clampAppearancePercent(appearance.intensity) == 100
+
+internal fun relativePdfSourceSampleSize(
+    baseSampleSize: Int,
+    profileMultiplier: Int,
+): Int {
+    require(
+        baseSampleSize > 0 && baseSampleSize and (baseSampleSize - 1) == 0 &&
+            profileMultiplier > 0 && profileMultiplier and (profileMultiplier - 1) == 0,
+    ) { "PDF sample sizes must be positive powers of two" }
+    require(baseSampleSize <= Int.MAX_VALUE / profileMultiplier) {
+        "PDF sample size exceeds integer bounds"
+    }
+    return baseSampleSize * profileMultiplier
+}

--- a/app/src/main/java/com/majkeylab/scanit/ScanAppearance.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanAppearance.kt
@@ -16,6 +16,71 @@ internal data class ScanAppearance(
     val shadows: Int = DEFAULT_SHADOWS,
 )
 
+internal data class ScanAppearanceSettings(
+    val colorMode: ScanColorMode = ScanColorMode.BlackWhite,
+    val colorIntensity: Int = DEFAULT_FILTER_INTENSITY,
+    val grayscaleIntensity: Int = DEFAULT_FILTER_INTENSITY,
+    val blackWhiteIntensity: Int = DEFAULT_FILTER_INTENSITY,
+    val shadows: Int = DEFAULT_SHADOWS,
+) {
+    fun selected(): ScanAppearance =
+        ScanAppearance(
+            colorMode = colorMode,
+            intensity = intensity(colorMode),
+            shadows = clampAppearancePercent(shadows),
+        )
+
+    fun intensity(mode: ScanColorMode): Int =
+        clampAppearancePercent(
+            when (mode) {
+                ScanColorMode.Color -> colorIntensity
+                ScanColorMode.Grayscale -> grayscaleIntensity
+                ScanColorMode.BlackWhite -> blackWhiteIntensity
+            },
+        )
+
+    fun withApplied(appearance: ScanAppearance): ScanAppearanceSettings =
+        copy(
+            colorMode = appearance.colorMode,
+            colorIntensity =
+                if (appearance.colorMode == ScanColorMode.Color) {
+                    clampAppearancePercent(appearance.intensity)
+                } else {
+                    colorIntensity
+                },
+            grayscaleIntensity =
+                if (appearance.colorMode == ScanColorMode.Grayscale) {
+                    clampAppearancePercent(appearance.intensity)
+                } else {
+                    grayscaleIntensity
+                },
+            blackWhiteIntensity =
+                if (appearance.colorMode == ScanColorMode.BlackWhite) {
+                    clampAppearancePercent(appearance.intensity)
+                } else {
+                    blackWhiteIntensity
+                },
+            shadows = clampAppearancePercent(appearance.shadows),
+        )
+}
+
+internal fun parseScanAppearanceSettings(
+    colorModeWireValue: String?,
+    colorIntensity: Int?,
+    grayscaleIntensity: Int?,
+    blackWhiteIntensity: Int?,
+    shadows: Int?,
+): ScanAppearanceSettings =
+    ScanAppearanceSettings(
+        colorMode =
+            ScanColorMode.entries.firstOrNull { it.wireValue == colorModeWireValue }
+                ?: ScanColorMode.BlackWhite,
+        colorIntensity = clampAppearancePercent(colorIntensity ?: DEFAULT_FILTER_INTENSITY),
+        grayscaleIntensity = clampAppearancePercent(grayscaleIntensity ?: DEFAULT_FILTER_INTENSITY),
+        blackWhiteIntensity = clampAppearancePercent(blackWhiteIntensity ?: DEFAULT_FILTER_INTENSITY),
+        shadows = clampAppearancePercent(shadows ?: DEFAULT_SHADOWS),
+    )
+
 internal fun clampAppearancePercent(value: Int): Int = value.coerceIn(0, 100)
 
 internal fun parseScanAppearance(

--- a/app/src/main/java/com/majkeylab/scanit/ScanAppearanceMetadata.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanAppearanceMetadata.kt
@@ -1,0 +1,214 @@
+package com.majkeylab.scanit
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+internal const val SCAN_APPEARANCE_FILE_NAME = "appearance.txt"
+internal const val SCAN_APPEARANCE_TEMP_FILE_NAME = ".appearance.txt.tmp"
+
+internal data class ScanAppearanceMetadata(
+    val appearance: ScanAppearance,
+    val appearanceSettings: ScanAppearanceSettings?,
+    val pdfSizeTarget: PdfSizeTarget,
+    val lineageCacheId: String,
+    val parentCacheId: String?,
+    val parentEntryId: String?,
+)
+
+internal fun encodeScanAppearanceMetadata(
+    appearanceSettings: ScanAppearanceSettings,
+    pdfSizeTarget: PdfSizeTarget,
+    lineageCacheId: String,
+    parentCacheId: String? = null,
+    parentEntryId: String? = null,
+): ByteArray {
+    requireSafeAppearanceIdentity(lineageCacheId, parentCacheId, parentEntryId)
+    val normalized = normalizeMetadataAppearance(appearanceSettings)
+    val relation =
+        if (parentCacheId == null) {
+            "initial\n"
+        } else {
+            "derived\n$parentCacheId\n$parentEntryId\n"
+        }
+    return (
+        "$SCAN_APPEARANCE_VERSION_V3\n${normalized.colorMode.wireValue}\n" +
+            "${normalized.colorIntensity}\n${normalized.grayscaleIntensity}\n" +
+            "${normalized.blackWhiteIntensity}\n${normalized.shadows}\n" +
+            "${pdfSizeTarget.wireValue}\n$lineageCacheId\n$relation"
+    ).toByteArray(StandardCharsets.US_ASCII)
+}
+
+internal fun decodeScanAppearanceMetadata(bytes: ByteArray): ScanAppearanceMetadata? {
+    if (bytes.isEmpty() || bytes.size > MAX_SCAN_APPEARANCE_BYTES || bytes.any { it < 0 }) return null
+    val text = String(bytes, StandardCharsets.US_ASCII)
+    return when {
+        text.startsWith("$SCAN_APPEARANCE_VERSION_V3\n") -> decodeV3Metadata(text)
+        text.startsWith("$SCAN_APPEARANCE_VERSION_V2\n") -> decodeV2Metadata(text)
+        else -> null
+    }
+}
+
+private fun decodeV3Metadata(text: String): ScanAppearanceMetadata? {
+    val fields = text.split('\n')
+    val derived = fields.getOrNull(8) == "derived"
+    if (fields.size != (if (derived) 12 else 10) || fields.last().isNotEmpty()) return null
+    if (fields[0] != SCAN_APPEARANCE_VERSION_V3) return null
+    val settings =
+        ScanAppearanceSettings(
+            colorMode = ScanColorMode.entries.firstOrNull { it.wireValue == fields[1] } ?: return null,
+            colorIntensity = strictPercent(fields[2]) ?: return null,
+            grayscaleIntensity = strictPercent(fields[3]) ?: return null,
+            blackWhiteIntensity = strictPercent(fields[4]) ?: return null,
+            shadows = strictPercent(fields[5]) ?: return null,
+        )
+    val target = PdfSizeTarget.entries.firstOrNull { it.wireValue == fields[6] } ?: return null
+    val lineageCacheId = fields[7]
+    val parentCacheId = if (derived) fields[9] else null
+    val parentEntryId = if (derived) fields[10] else null
+    if (!safeAppearanceIdentity(lineageCacheId, parentCacheId, parentEntryId)) return null
+    if (!derived && fields[8] != "initial") return null
+    return ScanAppearanceMetadata(
+        appearance = settings.selected(),
+        appearanceSettings = settings,
+        pdfSizeTarget = target,
+        lineageCacheId = lineageCacheId,
+        parentCacheId = parentCacheId,
+        parentEntryId = parentEntryId,
+    )
+}
+
+private fun decodeV2Metadata(text: String): ScanAppearanceMetadata? {
+    val match = SCAN_APPEARANCE_V2_PATTERN.matchEntire(text) ?: return null
+    val appearance =
+        ScanAppearance(
+            colorMode = ScanColorMode.entries.firstOrNull { it.wireValue == match.groupValues[1] }
+                ?: return null,
+            intensity = strictPercent(match.groupValues[2]) ?: return null,
+            shadows = strictPercent(match.groupValues[3]) ?: return null,
+        )
+    val target = PdfSizeTarget.entries.firstOrNull { it.wireValue == match.groupValues[4] }
+        ?: return null
+    val lineageCacheId = match.groupValues[5]
+    if (!isSafeAppearanceCacheId(lineageCacheId)) return null
+    return ScanAppearanceMetadata(
+        appearance = appearance,
+        appearanceSettings = null,
+        pdfSizeTarget = target,
+        lineageCacheId = lineageCacheId,
+        parentCacheId = null,
+        parentEntryId = null,
+    )
+}
+
+internal fun readScanAppearanceMetadata(
+    directory: File,
+    expectedCacheId: String = directory.name,
+): ScanAppearanceMetadata? {
+    val file = File(directory, SCAN_APPEARANCE_FILE_NAME)
+    if (!file.isFile || file.length() !in 1..MAX_SCAN_APPEARANCE_BYTES.toLong()) return null
+    val metadata =
+        try {
+            decodeScanAppearanceMetadata(Files.readAllBytes(file.toPath()))
+        } catch (_: IOException) {
+            null
+        } ?: return null
+    if (metadata.appearanceSettings != null) {
+        if (metadata.parentCacheId == null && metadata.lineageCacheId != expectedCacheId) return null
+        if (metadata.parentCacheId == expectedCacheId) return null
+    }
+    return metadata
+}
+
+internal fun writeScanAppearanceMetadata(
+    directory: File,
+    appearanceSettings: ScanAppearanceSettings,
+    pdfSizeTarget: PdfSizeTarget = PdfSizeTarget.Original,
+    lineageCacheId: String = directory.name,
+    parentCacheId: String? = null,
+    parentEntryId: String? = null,
+) {
+    val parent = directory.absoluteFile
+    require(parent.isDirectory) { "Appearance metadata directory does not exist" }
+    val target = File(parent, SCAN_APPEARANCE_FILE_NAME)
+    val temporary = File(parent, SCAN_APPEARANCE_TEMP_FILE_NAME)
+    var failure: Throwable? = null
+    try {
+        FileOutputStream(temporary).use { output ->
+            output.write(
+                encodeScanAppearanceMetadata(
+                    appearanceSettings,
+                    pdfSizeTarget,
+                    lineageCacheId,
+                    parentCacheId,
+                    parentEntryId,
+                ),
+            )
+            output.fd.sync()
+        }
+        Files.move(
+            temporary.toPath(),
+            target.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+    } catch (throwable: Throwable) {
+        failure = throwable
+        throw throwable
+    } finally {
+        if (temporary.exists() && !temporary.delete()) {
+            val cleanup = IOException("Incomplete appearance metadata could not be deleted")
+            failure?.addSuppressed(cleanup) ?: throw cleanup
+        }
+    }
+}
+
+private fun normalizeMetadataAppearance(settings: ScanAppearanceSettings): ScanAppearanceSettings =
+    parseScanAppearanceSettings(
+        colorModeWireValue = settings.colorMode.wireValue,
+        colorIntensity = settings.colorIntensity,
+        grayscaleIntensity = settings.grayscaleIntensity,
+        blackWhiteIntensity = settings.blackWhiteIntensity,
+        shadows = settings.shadows,
+    )
+
+private fun strictPercent(value: String): Int? = value.toIntOrNull()?.takeIf { it in 0..100 }
+
+private fun requireSafeAppearanceIdentity(
+    lineageCacheId: String,
+    parentCacheId: String?,
+    parentEntryId: String?,
+) {
+    require(safeAppearanceIdentity(lineageCacheId, parentCacheId, parentEntryId)) {
+        "Appearance identity is invalid"
+    }
+}
+
+private fun safeAppearanceIdentity(
+    lineageCacheId: String,
+    parentCacheId: String?,
+    parentEntryId: String?,
+): Boolean =
+    isSafeAppearanceCacheId(lineageCacheId) &&
+        ((parentCacheId == null && parentEntryId == null) ||
+            (parentCacheId != null &&
+                isSafeAppearanceCacheId(parentCacheId) &&
+                parentEntryId != null &&
+                isCanonicalUuid(parentEntryId)))
+
+private fun isSafeAppearanceCacheId(value: String): Boolean =
+    value.length <= MAX_APPEARANCE_CACHE_ID_LENGTH && isSafeCacheId(value)
+
+private const val SCAN_APPEARANCE_VERSION_V2 = "scanit-appearance-v2"
+private const val SCAN_APPEARANCE_VERSION_V3 = "scanit-appearance-v3"
+private const val MAX_SCAN_APPEARANCE_BYTES = 640
+private const val MAX_APPEARANCE_CACHE_ID_LENGTH = 128
+private val SCAN_APPEARANCE_V2_PATTERN =
+    Regex(
+        "$SCAN_APPEARANCE_VERSION_V2\\n(color|grayscale|black_white)\\n" +
+            "([0-9]{1,3})\\n([0-9]{1,3})\\n(original|5_mb|10_mb|20_mb)\\n" +
+            "([^\\r\\n]{1,$MAX_APPEARANCE_CACHE_ID_LENGTH})\\n",
+    )

--- a/app/src/main/java/com/majkeylab/scanit/ScanAppearanceRenderer.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanAppearanceRenderer.kt
@@ -27,6 +27,7 @@ internal object ScanAppearanceRenderer {
         source: File,
         destination: File,
         appearance: ScanAppearance,
+        minimumSampleSize: Int = 1,
         isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
     ): RenderedJpeg {
         val input = source.canonicalFile
@@ -41,7 +42,12 @@ internal object ScanAppearanceRenderer {
         val sourceLength = input.length()
         val sourceModified = input.lastModified()
         val bounds = readJpegBounds(input)
-        val sampleSize = appearanceDecodeSampleSize(bounds.width, bounds.height)
+        val sampleSize =
+            appearanceDecodeSampleSize(
+                bounds.width,
+                bounds.height,
+                minimumSampleSize = minimumSampleSize,
+            )
         val bitmap = decodeMutableBitmap(input, sampleSize)
         val width = bitmap.width
         val height = bitmap.height
@@ -272,10 +278,15 @@ internal fun appearanceDecodeSampleSize(
     height: Int,
     maxPixels: Long = MAX_RENDER_PIXELS,
     maxEdge: Int = MAX_RENDER_EDGE,
+    minimumSampleSize: Int = 1,
 ): Int {
     require(width > 0 && height > 0) { "Image dimensions must be positive" }
     require(maxPixels > 0 && maxEdge > 0) { "Render bounds must be positive" }
-    var sampleSize = 1
+    require(
+        minimumSampleSize > 0 &&
+            minimumSampleSize and (minimumSampleSize - 1) == 0,
+    ) { "Minimum sample size must be a positive power of two" }
+    var sampleSize = minimumSampleSize
     while (true) {
         val sampledWidth = sampledDimensionUpperBound(width, sampleSize)
         val sampledHeight = sampledDimensionUpperBound(height, sampleSize)

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -10,6 +10,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 internal const val DEFAULT_ALBUM_NAME = "Scan to PDF"
+internal const val MAX_SCAN_PAGES = 20
 
 internal data class AppSettings(
     val savePdf: Boolean = true,
@@ -22,6 +23,8 @@ internal data class AppSettings(
     val pdfTreeUri: String? = null,
     val deletePdfAfterShare: Boolean = false,
     val deleteImagesAfterShare: Boolean = false,
+    val appearance: ScanAppearanceSettings = ScanAppearanceSettings(),
+    val pdfSizeTarget: PdfSizeTarget = PdfSizeTarget.Original,
 )
 
 internal enum class RecentDeleteTarget {
@@ -225,15 +228,39 @@ internal fun localizedDefaultEmailSubject(
 
 internal data class UiMessage(
     val resourceId: Int,
-    val formatArgs: List<Int> = emptyList(),
+    val formatArgs: List<Any> = emptyList(),
 )
+
+internal fun pdfSizeTargetWarning(
+    target: PdfSizeTarget,
+    bytes: Long,
+): UiMessage? {
+    val targetBytes = target.maxBytes ?: return null
+    if (bytes <= 0L || bytes <= targetBytes) return null
+    return UiMessage(
+        R.string.pdf_size_target_not_met,
+        listOf(
+            (targetBytes / PDF_DISPLAY_BYTES).toInt(),
+            bytes / PDF_DISPLAY_BYTES.toDouble(),
+        ),
+    )
+}
 
 internal data class CachedScan(
     val baseName: String,
     val pages: List<File>,
     val pdf: File,
     val entryId: String? = null,
+    val sourcePages: List<File> = emptyList(),
+    val appearance: ScanAppearance? = null,
+    val appearanceSettings: ScanAppearanceSettings? = null,
+    val pdfSizeTarget: PdfSizeTarget = PdfSizeTarget.Original,
+    val lineageCacheId: String = baseName,
+    val parentCacheId: String? = null,
+    val parentEntryId: String? = null,
 )
+
+private const val PDF_DISPLAY_BYTES = 1_000_000L
 
 internal data class SavedScan(
     val cached: CachedScan,
@@ -466,6 +493,8 @@ internal sealed interface ScreenState {
         val selectedPageIndex: Int = 0,
         val pagePreviewLoading: Boolean = false,
         val outputSaveInProgress: Boolean = false,
+        val appearanceApplyInProgress: Boolean = false,
+        val appearanceMessage: UiMessage? = null,
     ) : ScreenState
 
     data class Recent(
@@ -480,6 +509,7 @@ internal sealed interface ScreenState {
 internal enum class AppBackAction {
     CloseSettings,
     CollapseFileDetails,
+    CollapseAppearance,
     ShowRecent,
     LaunchScanner,
     Consume,
@@ -489,10 +519,13 @@ internal fun appBackAction(
     settingsOpen: Boolean,
     fileDetailsOpen: Boolean,
     state: ScreenState,
+    appearanceOpen: Boolean = false,
 ): AppBackAction =
     when {
         settingsOpen -> AppBackAction.CloseSettings
-        state is ScreenState.Result && state.outputSaveInProgress -> AppBackAction.Consume
+        state is ScreenState.Result &&
+            (state.outputSaveInProgress || state.appearanceApplyInProgress) -> AppBackAction.Consume
+        appearanceOpen && state is ScreenState.Result -> AppBackAction.CollapseAppearance
         fileDetailsOpen && state is ScreenState.Result -> AppBackAction.CollapseFileDetails
         state is ScreenState.Processing && !state.canNavigateBack -> AppBackAction.Consume
         state is ScreenState.Recent && state.deletionInProgress -> AppBackAction.Consume

--- a/app/src/main/java/com/majkeylab/scanit/ScanPdfBuilder.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanPdfBuilder.kt
@@ -1,0 +1,195 @@
+package com.majkeylab.scanit
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CancellationException
+
+internal data class ScanPdfBuildPage(
+    val longestEdge: Int,
+    val renderJpeg: (workingDirectory: File, sampleMultiplier: Int) -> JpegPdfPage,
+    val createBitonal: (JpegPdfPage) -> BitonalPdfPage,
+)
+
+internal data class ScanPdfBuildResult(
+    val bytes: Long,
+    val target: PdfSizeTarget,
+    val targetMet: Boolean,
+    val sampleMultiplier: Int,
+    val encoding: PdfEncoding,
+)
+
+internal fun buildScanPdf(
+    output: File,
+    pages: List<ScanPdfBuildPage>,
+    target: PdfSizeTarget,
+    bitonalEligible: Boolean,
+    isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+): ScanPdfBuildResult {
+    require(pages.isNotEmpty() && pages.all { it.longestEdge > 0 }) {
+        "PDF build pages must have positive dimensions"
+    }
+    require(pages.size <= MAX_SCAN_PAGES) {
+        "PDF page count exceeds $MAX_SCAN_PAGES"
+    }
+    val destination = output.absoluteFile
+    val parent = requireNotNull(destination.parentFile) { "PDF destination must have a parent" }
+    require(parent.isDirectory) { "PDF destination directory does not exist" }
+    require(!destination.exists()) { "PDF destination already exists" }
+    val workingDirectory =
+        Files.createTempDirectory(parent.toPath(), ".scanit-pdf-build-").toFile()
+    var publicationStaging: Path? = null
+    var failure: Throwable? = null
+    try {
+        throwIfPdfBuildCancelled(isCancelled)
+        val multipliers =
+            if (target == PdfSizeTarget.Original) {
+                listOf(1)
+            } else {
+                pdfSampleMultipliers(pages.map(ScanPdfBuildPage::longestEdge))
+            }
+        var selected: ScanPdfCandidate? = null
+        for (sampleMultiplier in multipliers) {
+            throwIfPdfBuildCancelled(isCancelled)
+            val profileDirectory = File(workingDirectory, "profile-$sampleMultiplier")
+            check(profileDirectory.mkdir()) { "PDF profile directory could not be created" }
+            var profileFailure: Throwable? = null
+            try {
+                val renderedPages =
+                    pages.map { page ->
+                        throwIfPdfBuildCancelled(isCancelled)
+                        val pageMultiplier =
+                            legiblePdfSampleMultiplier(page.longestEdge, sampleMultiplier)
+                        page.renderJpeg(profileDirectory, pageMultiplier)
+                    }
+                val jpeg = File(profileDirectory, "jpeg.pdf")
+                JpegPdfWriter.write(jpeg, renderedPages, isCancelled)
+                throwIfPdfBuildCancelled(isCancelled)
+                val bitonal =
+                    if (bitonalEligible) {
+                        writeBitonalCandidate(profileDirectory, renderedPages, pages, isCancelled)
+                    } else {
+                        null
+                    }
+                val encoding = selectPdfEncoding(jpeg.length(), bitonal?.length(), bitonalEligible)
+                val chosen = if (encoding == PdfEncoding.Bitonal) requireNotNull(bitonal) else jpeg
+                val candidateBytes = chosen.length()
+                val targetMet = target.maxBytes?.let { candidateBytes <= it } ?: true
+                if (selected == null || candidateBytes < selected.bytes) {
+                    val retained = File(workingDirectory, "candidate-$sampleMultiplier.pdf")
+                    Files.createLink(retained.toPath(), chosen.toPath())
+                    val previous = selected
+                    selected =
+                        ScanPdfCandidate(sampleMultiplier, candidateBytes, encoding, retained)
+                    if (previous != null && previous.file.exists() && !previous.file.delete()) {
+                        throw IOException("Previous PDF candidate could not be deleted")
+                    }
+                }
+                if (targetMet) break
+            } catch (throwable: Throwable) {
+                profileFailure = throwable
+                throw throwable
+            } finally {
+                try {
+                    deletePdfBuildDirectory(profileDirectory)
+                } catch (cleanupFailure: Throwable) {
+                    profileFailure?.addSuppressed(cleanupFailure) ?: throw cleanupFailure
+                }
+            }
+        }
+
+        val completed = checkNotNull(selected) { "PDF build did not produce a candidate" }
+        throwIfPdfBuildCancelled(isCancelled)
+        publicationStaging = createPdfPublicationStaging(parent, completed.file)
+        deletePdfBuildDirectory(workingDirectory)
+        throwIfPdfBuildCancelled(isCancelled)
+        publishStagedFileNoReplace(checkNotNull(publicationStaging), destination.toPath())
+        publicationStaging = null
+        return ScanPdfBuildResult(
+            bytes = destination.length(),
+            target = target,
+            targetMet = target.maxBytes?.let { completed.bytes <= it } ?: true,
+            sampleMultiplier = completed.sampleMultiplier,
+            encoding = completed.encoding,
+        )
+    } catch (throwable: Throwable) {
+        failure = throwable
+        throw throwable
+    } finally {
+        var cleanupFailure: Throwable? = null
+        try {
+            deletePdfBuildDirectory(workingDirectory)
+        } catch (throwable: Throwable) {
+            cleanupFailure = throwable
+        }
+        try {
+            publicationStaging?.let(Files::deleteIfExists)
+        } catch (throwable: Throwable) {
+            cleanupFailure?.addSuppressed(throwable) ?: run { cleanupFailure = throwable }
+        }
+        cleanupFailure?.let { throwable ->
+            failure?.addSuppressed(throwable) ?: throw throwable
+        }
+    }
+}
+
+private fun writeBitonalCandidate(
+    profileDirectory: File,
+    renderedPages: List<JpegPdfPage>,
+    pages: List<ScanPdfBuildPage>,
+    isCancelled: () -> Boolean,
+): File? {
+    val bitonal = File(profileDirectory, "bitonal.pdf")
+    return try {
+        val bitonalPages =
+            renderedPages.mapIndexed { index, page ->
+                throwIfPdfBuildCancelled(isCancelled)
+                pages[index].createBitonal(page)
+            }
+        throwIfPdfBuildCancelled(isCancelled)
+        BitonalPdfWriter.write(bitonal, bitonalPages, isCancelled)
+        bitonal
+    } catch (failure: CancellationException) {
+        throw failure
+    } catch (_: IOException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
+
+private fun createPdfPublicationStaging(parent: File, candidate: File): Path {
+    val staging = Files.createTempFile(parent.toPath(), ".scanit-pdf-ready-", ".part")
+    try {
+        Files.delete(staging)
+        Files.createLink(staging, candidate.toPath())
+        return staging
+    } catch (failure: Throwable) {
+        try {
+            Files.deleteIfExists(staging)
+        } catch (cleanupFailure: Throwable) {
+            failure.addSuppressed(cleanupFailure)
+        }
+        throw failure
+    }
+}
+
+private fun deletePdfBuildDirectory(directory: File) {
+    directory.walkBottomUp().forEach { file ->
+        if (file.exists() && !file.delete()) {
+            throw IOException("PDF build working file could not be deleted")
+        }
+    }
+}
+
+private fun throwIfPdfBuildCancelled(isCancelled: () -> Boolean) {
+    if (isCancelled()) throw CancellationException("PDF build cancelled")
+}
+
+private data class ScanPdfCandidate(
+    val sampleMultiplier: Int,
+    val bytes: Long,
+    val encoding: PdfEncoding,
+    val file: File,
+)

--- a/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
@@ -52,6 +52,8 @@ internal inline fun <T> tryStorageTransaction(operation: () -> T): T? {
         storageTransactionLock.unlock()
     }
 }
+private const val PROVISIONAL_CACHE_MARKER = ".provisional"
+private const val ACTIVATION_ROLLBACK_MARKER = ".activation-rollback"
 private val MEDIA_IDENTITY_PROJECTION =
     arrayOf(
         MediaStore.MediaColumns._ID,
@@ -103,6 +105,11 @@ internal data class FitRect(
     val bottom: Float,
 )
 
+internal data class CachedScanBuild(
+    val cached: CachedScan,
+    val pdf: ScanPdfBuildResult,
+)
+
 internal fun scanPageFileName(
     baseName: String,
     pageNumber: Int,
@@ -111,6 +118,16 @@ internal fun scanPageFileName(
     require(pageNumber > 0) { "Page number must be positive" }
     val page = pageNumber.toString().padStart(2, '0')
     return "${baseName}_${page}.jpg"
+}
+
+internal fun scanSourcePageFileName(
+    baseName: String,
+    pageNumber: Int,
+): String {
+    require(baseName.isNotBlank()) { "Scan base name must not be blank" }
+    require(pageNumber > 0) { "Page number must be positive" }
+    val page = pageNumber.toString().padStart(2, '0')
+    return "${baseName}_source_${page}.jpg"
 }
 
 internal fun scanPdfFileName(baseName: String): String {
@@ -163,6 +180,7 @@ private data class ParsedCacheEntry(
     val recent: RecentScan,
     val cached: CachedScan,
     val outputs: OutputMetadata?,
+    val provisional: Boolean,
 )
 
 internal fun nextDerivedCacheId(
@@ -282,11 +300,7 @@ private fun publishCacheEntryInRoot(
         throw IOException("Cache publication path is unsafe")
     }
 
-    val recoveryDirectory = File(safeRoot, "$RECOVERY_PENDING_PREFIX$cacheId")
-    val deleteDirectory = File(safeRoot, "$DELETE_PENDING_PREFIX$cacheId")
-    val commitMarker = File(safeRoot, "$COMMITTED_PRUNE_PREFIX$cacheId")
     var published = false
-    var committed = false
     try {
         maintainPendingDirectories(safeRoot, work)
         val entriesToPrune = entriesToPrune(safeRoot, protectedCacheIds, maxEntries - 1)
@@ -306,53 +320,10 @@ private fun publishCacheEntryInRoot(
         published = true
         val cached = readCacheEntry(safeRoot, final, cacheId)?.cached
             ?: throw IOException("Published cache entry is incomplete")
-        if (entriesToPrune.isNotEmpty()) {
-            if (
-                recoveryDirectory.exists() ||
-                    deleteDirectory.exists() ||
-                    commitMarker.exists() ||
-                    !recoveryDirectory.mkdir()
-            ) {
-                throw IOException("Recent scan recovery directory could not be created")
-            }
-            entriesToPrune.forEach { entry ->
-                if (readCacheEntry(safeRoot, entry.directory, entry.recent.cacheId) == null) {
-                    if (!entry.directory.exists()) return@forEach
-                    throw IOException("Recent scan changed before pruning")
-                }
-                moveEntry(
-                    entry.directory.toPath(),
-                    File(recoveryDirectory, entry.recent.cacheId).toPath(),
-                )
-            }
-            moveEntry(recoveryDirectory.toPath(), deleteDirectory.toPath())
-            if (!commitMarker.createNewFile()) {
-                throw IOException("Recent scan prune could not be committed")
-            }
-            committed = true
-            deleteCommittedPrune(deleteDirectory, commitMarker)
-        }
+        commitCacheEntryRemovals(safeRoot, cacheId, entriesToPrune, moveEntry)
         return cached
     } catch (failure: Throwable) {
         var reportedFailure = failure
-        if (!committed) {
-            val recoverySource =
-                when {
-                    recoveryDirectory.exists() -> recoveryDirectory
-                    deleteDirectory.exists() -> deleteDirectory
-                    else -> null
-                }
-            try {
-                recoverySource?.let {
-                    restoreRecoveryDirectory(safeRoot, it, cacheId, moveEntry)
-                }
-            } catch (restoreFailure: Exception) {
-                reportedFailure =
-                    IOException("Recent scan recovery is pending", restoreFailure).also {
-                        it.addSuppressed(failure)
-                    }
-            }
-        }
         val cleanupTarget = if (published || (!work.exists() && final.exists())) final else work
         if (
             isDirectChild(safeRoot, cleanupTarget) &&
@@ -364,6 +335,278 @@ private fun publishCacheEntryInRoot(
             )
         }
         throw reportedFailure
+    }
+}
+
+private fun publishProvisionalCacheEntryInRoot(
+    root: File,
+    workDir: File,
+    finalDir: File,
+    moveEntry: (Path, Path) -> Unit,
+): CachedScan {
+    val safeRoot = ensureShareRoot(root)
+    val work = workDir.absoluteFile
+    if (!isCreatePendingDirectory(safeRoot, work)) {
+        throw IOException("Provisional cache publication path is unsafe")
+    }
+    try {
+        val marker = File(work, PROVISIONAL_CACHE_MARKER)
+        if (!marker.createNewFile()) {
+            throw IOException("Reserved provisional cache marker already exists")
+        }
+        return publishCacheEntryInRoot(
+            root = safeRoot,
+            workDir = work,
+            finalDir = finalDir,
+            maxEntries = Int.MAX_VALUE,
+            moveEntry = moveEntry,
+        )
+    } catch (failure: Throwable) {
+        if (work.exists() && !deleteTreeWithoutFollowingLinks(work)) {
+            failure.addSuppressed(IOException("Failed provisional cache could not be deleted"))
+        }
+        throw failure
+    }
+}
+
+private fun activateProvisionalCacheEntryInRoot(
+    root: File,
+    candidateCacheId: String,
+    retireCacheId: String?,
+    protectedCacheIds: Set<String>,
+    maxEntries: Int,
+    moveEntry: (Path, Path) -> Unit,
+): CachedScan {
+    require(maxEntries > 0) { "Recent scan retention must be positive for activation" }
+    require(protectedCacheIds.all(::isSafeCacheId)) { "Protected cache ID is unsafe" }
+    val safeRoot = ensureShareRoot(root)
+    maintainPendingDirectories(safeRoot)
+    if (!isSafeCacheId(candidateCacheId)) throw IOException("Candidate cache ID is unsafe")
+    val candidateDirectory = File(safeRoot, candidateCacheId).absoluteFile
+    val candidate = readCacheEntry(safeRoot, candidateDirectory, candidateCacheId)
+        ?.takeIf(ParsedCacheEntry::provisional)
+        ?: throw IOException("Provisional cache entry is unavailable")
+    var activated: CachedScan? = null
+    try {
+        val entriesToRemove =
+            activationEntriesToRemove(
+                safeRoot,
+                retireCacheId,
+                candidate.cached.lineageCacheId,
+                protectedCacheIds,
+                maxEntries - 1,
+            )
+        commitCacheEntryRemovals(
+            root = safeRoot,
+            publishedCacheId = candidateCacheId,
+            entries = entriesToRemove,
+            moveEntry = moveEntry,
+            preservePublishedOnRollback = true,
+        ) {
+            Files.delete(File(candidateDirectory, PROVISIONAL_CACHE_MARKER).toPath())
+            activated =
+                readCacheEntry(safeRoot, candidateDirectory, candidateCacheId)
+                    ?.takeUnless(ParsedCacheEntry::provisional)
+                    ?.cached
+                    ?: throw IOException("Activated cache entry is incomplete")
+        }
+        return checkNotNull(activated)
+    } catch (failure: Throwable) {
+        try {
+            ensureProvisionalCacheMarker(safeRoot, candidateCacheId)
+        } catch (restoreFailure: Exception) {
+            failure.addSuppressed(restoreFailure)
+        }
+        throw failure
+    }
+}
+
+private fun isProvisionalCacheEntryInRoot(root: File, cacheId: String): Boolean {
+    if (!isSafeCacheId(cacheId)) return false
+    val safeRoot = ensureShareRoot(root)
+    maintainPendingDirectories(safeRoot)
+    return readCacheEntry(safeRoot, File(safeRoot, cacheId).absoluteFile, cacheId)?.provisional == true
+}
+
+private fun reconcileProvisionalCacheEntriesInRoot(
+    root: File,
+    authoritativeCacheId: String?,
+) {
+    val safeRoot = ensureShareRoot(root)
+    maintainPendingDirectories(safeRoot)
+    val entries = readCacheEntries(safeRoot, includeProvisional = true)
+    if (authoritativeCacheId != null) {
+        if (
+            !isSafeCacheId(authoritativeCacheId) ||
+                entries.none {
+                    it.provisional && it.recent.cacheId == authoritativeCacheId
+                }
+        ) {
+            throw IOException("Authoritative provisional cache entry is unavailable")
+        }
+    }
+    entries
+        .filter {
+            it.provisional && it.recent.cacheId != authoritativeCacheId
+        }.forEach { entry ->
+            if (!deleteTreeWithoutFollowingLinks(entry.directory)) {
+                throw IOException("Orphaned provisional cache entry could not be deleted")
+            }
+        }
+}
+
+private fun activateCheckpointProvisionalCacheEntryInRoot(
+    root: File,
+    candidateCacheId: String,
+    maxEntries: Int,
+    moveEntry: (Path, Path) -> Unit,
+): CachedScan {
+    val safeRoot = ensureShareRoot(root)
+    maintainPendingDirectories(safeRoot)
+    if (!isSafeCacheId(candidateCacheId)) throw IOException("Candidate cache ID is unsafe")
+    val candidate =
+        readCacheEntry(
+            safeRoot,
+            File(safeRoot, candidateCacheId).absoluteFile,
+            candidateCacheId,
+    ) ?: throw IOException("Checkpoint cache entry is unavailable")
+    if (!candidate.provisional) return candidate.cached
+    val parentCacheId = candidate.cached.parentCacheId
+        ?: throw IOException("Provisional cache parent is unavailable")
+    val parentEntryId = candidate.cached.parentEntryId
+        ?: throw IOException("Provisional cache parent generation is unavailable")
+    if (candidate.cached.appearanceSettings == null) {
+        throw IOException("Provisional cache appearance authority is unavailable")
+    }
+    val parent = readCacheEntries(safeRoot).singleOrNull {
+        it.recent.cacheId == parentCacheId
+    }
+    val exactParent = parent?.takeIf { it.cached.entryId == parentEntryId }
+    if (exactParent != null && exactParent.cached.lineageCacheId != candidate.cached.lineageCacheId) {
+        throw IOException("Provisional cache parent belongs to another lineage")
+    }
+    val retireParent =
+        exactParent?.takeIf { entry ->
+            entry.outputs?.let { it.pdf == null && it.images.isEmpty() } == true
+        }
+    val protectedParent =
+        parent?.takeUnless { it === retireParent }?.recent?.cacheId?.let(::setOf).orEmpty()
+    return activateProvisionalCacheEntryInRoot(
+        root = safeRoot,
+        candidateCacheId = candidateCacheId,
+        retireCacheId = retireParent?.recent?.cacheId,
+        protectedCacheIds = protectedParent,
+        maxEntries = maxEntries,
+        moveEntry = moveEntry,
+    )
+}
+
+private fun activationEntriesToRemove(
+    root: File,
+    retireCacheId: String?,
+    candidateLineageCacheId: String,
+    protectedCacheIds: Set<String>,
+    activeCapacity: Int,
+): List<ParsedCacheEntry> {
+    require(activeCapacity >= 0) { "Active cache capacity must not be negative" }
+    if (retireCacheId != null && !isSafeCacheId(retireCacheId)) {
+        throw IOException("Retired cache ID is unsafe")
+    }
+    if (retireCacheId != null && retireCacheId in protectedCacheIds) {
+        throw IOException("Retired cache entry cannot also be protected")
+    }
+    val entries = readCacheEntries(root)
+    val retired =
+        retireCacheId?.let { id ->
+            val entry =
+                entries.singleOrNull { it.recent.cacheId == id }
+                    ?: throw IOException("Retired cache entry is unavailable")
+            if (entry.cached.lineageCacheId != candidateLineageCacheId) {
+                throw IOException("Retired cache entry belongs to another lineage")
+            }
+            entry
+        }
+    val remaining = entries.filterNot { it === retired }
+    val protectedEntries = remaining.filter { it.recent.cacheId in protectedCacheIds }
+    if (protectedEntries.size > activeCapacity) {
+        throw IOException("Protected recent scans exceed cache capacity")
+    }
+    val protectedDirectories = protectedEntries.mapTo(mutableSetOf(), ParsedCacheEntry::directory)
+    val unprotected = remaining.filterNot { it.directory in protectedDirectories }
+    val unprotectedToKeep = activeCapacity - protectedEntries.size
+    val directoriesToDelete =
+        shareCacheEntriesToPrune(unprotected.map(ParsedCacheEntry::directory), unprotectedToKeep)
+            .toSet()
+    return listOfNotNull(retired) + remaining.filter { it.directory in directoriesToDelete }
+}
+
+private fun commitCacheEntryRemovals(
+    root: File,
+    publishedCacheId: String,
+    entries: List<ParsedCacheEntry>,
+    moveEntry: (Path, Path) -> Unit,
+    preservePublishedOnRollback: Boolean = false,
+    beforeCommit: () -> Unit = {},
+) {
+    if (entries.isEmpty()) {
+        beforeCommit()
+        return
+    }
+    val recoveryDirectory = File(root, "$RECOVERY_PENDING_PREFIX$publishedCacheId")
+    val deleteDirectory = File(root, "$DELETE_PENDING_PREFIX$publishedCacheId")
+    val commitMarker = File(root, "$COMMITTED_PRUNE_PREFIX$publishedCacheId")
+    if (
+        recoveryDirectory.exists() ||
+            deleteDirectory.exists() ||
+            commitMarker.exists() ||
+            !recoveryDirectory.mkdir()
+    ) {
+        throw IOException("Recent scan recovery directory could not be created")
+    }
+    if (
+        preservePublishedOnRollback &&
+            !File(recoveryDirectory, ACTIVATION_ROLLBACK_MARKER).createNewFile()
+    ) {
+        deleteTreeWithoutFollowingLinks(recoveryDirectory)
+        throw IOException("Activation recovery marker could not be created")
+    }
+    var committed = false
+    try {
+        entries.forEach { entry ->
+            if (readCacheEntry(root, entry.directory, entry.recent.cacheId) == null) {
+                if (!entry.directory.exists()) return@forEach
+                throw IOException("Recent scan changed before pruning")
+            }
+            moveEntry(
+                entry.directory.toPath(),
+                File(recoveryDirectory, entry.recent.cacheId).toPath(),
+            )
+        }
+        beforeCommit()
+        moveEntry(recoveryDirectory.toPath(), deleteDirectory.toPath())
+        if (!commitMarker.createNewFile()) {
+            throw IOException("Recent scan prune could not be committed")
+        }
+        committed = true
+        deleteCommittedPrune(deleteDirectory, commitMarker)
+    } catch (failure: Throwable) {
+        if (committed) throw failure
+        val recoverySource =
+            when {
+                recoveryDirectory.exists() -> recoveryDirectory
+                deleteDirectory.exists() -> deleteDirectory
+                else -> null
+            }
+        try {
+            recoverySource?.let {
+                restoreRecoveryDirectory(root, it, publishedCacheId, moveEntry)
+            }
+        } catch (restoreFailure: Exception) {
+            throw IOException("Recent scan recovery is pending", restoreFailure).also {
+                it.addSuppressed(failure)
+            }
+        }
+        throw failure
     }
 }
 
@@ -391,7 +634,8 @@ private fun entriesToPrune(
     if (protectedEntries.size > maxEntries) {
         throw IOException("Protected recent scans exceed cache capacity")
     }
-    val unprotected = entries.filterNot { it.recent.cacheId in protectedCacheIds }
+    val protectedDirectories = protectedEntries.mapTo(mutableSetOf(), ParsedCacheEntry::directory)
+    val unprotected = entries.filterNot { it.directory in protectedDirectories }
     val unprotectedToKeep = maxEntries - protectedEntries.size
     val directoriesToDelete =
         shareCacheEntriesToPrune(unprotected.map(ParsedCacheEntry::directory), unprotectedToKeep)
@@ -403,10 +647,14 @@ private fun moveCacheEntryAtomically(source: Path, target: Path) {
     Files.move(source, target, StandardCopyOption.ATOMIC_MOVE)
 }
 
-private fun readCacheEntries(root: File): List<ParsedCacheEntry> {
+private fun readCacheEntries(
+    root: File,
+    includeProvisional: Boolean = false,
+): List<ParsedCacheEntry> {
     val children = root.listFiles() ?: throw IOException("Share cache could not be listed")
     return children
         .mapNotNull { child -> readCacheEntry(root, child.absoluteFile, child.name) }
+        .filter { includeProvisional || !it.provisional }
         .sortedWith(
             compareByDescending<ParsedCacheEntry> { it.recent.createdAt }
                 .thenBy { it.recent.cacheId },
@@ -448,8 +696,11 @@ private fun readCacheEntry(
     }
     val children = directory.listFiles() ?: return null
     val pagePattern = Regex("${Regex.escape(cacheId)}_([0-9]+)\\.jpg")
+    val sourcePagePattern = Regex("${Regex.escape(cacheId)}_source_([0-9]+)\\.jpg")
     val pagesByNumber = mutableMapOf<Int, File>()
+    val sourcePagesByNumber = mutableMapOf<Int, File>()
     var pdf: File? = null
+    var provisional = false
     children.forEach { child ->
         val file = child.absoluteFile
         if (
@@ -462,6 +713,11 @@ private fun readCacheEntry(
             OUTPUT_METADATA_FILE_NAME,
             OUTPUT_METADATA_TEMP_FILE_NAME,
             -> Unit
+            SCAN_APPEARANCE_FILE_NAME -> Unit
+            PROVISIONAL_CACHE_MARKER -> {
+                if (file.length() != 0L) return null
+                provisional = true
+            }
             scanPdfFileName(cacheId) -> {
                 if (file.length() <= 0L) return null
                 if (pdf != null) return null
@@ -469,6 +725,18 @@ private fun readCacheEntry(
             }
             else -> {
                 if (file.length() <= 0L) return null
+                val sourceMatch = sourcePagePattern.matchEntire(file.name)
+                if (sourceMatch != null) {
+                    val pageNumber = sourceMatch.groupValues[1].toIntOrNull() ?: return null
+                    if (
+                        pageNumber <= 0 ||
+                            file.name != scanSourcePageFileName(cacheId, pageNumber) ||
+                            sourcePagesByNumber.put(pageNumber, file) != null
+                    ) {
+                        return null
+                    }
+                    return@forEach
+                }
                 val match = pagePattern.matchEntire(file.name) ?: return null
                 val pageNumber = match.groupValues[1].toIntOrNull() ?: return null
                 if (
@@ -482,14 +750,22 @@ private fun readCacheEntry(
         }
     }
     val orderedPages = pagesByNumber.toSortedMap().values.toList()
+    val orderedSourcePages = sourcePagesByNumber.toSortedMap().values.toList()
     if (
         pdf == null ||
             orderedPages.isEmpty() ||
-            pagesByNumber.keys.sorted() != (1..orderedPages.size).toList()
+            pagesByNumber.keys.sorted() != (1..orderedPages.size).toList() ||
+            orderedSourcePages.isNotEmpty() &&
+            (
+                orderedSourcePages.size != orderedPages.size ||
+                    sourcePagesByNumber.keys.sorted() != (1..orderedSourcePages.size).toList()
+            )
     ) {
         return null
     }
     val exactPdf = pdf
+    val appearanceMetadata = readScanAppearanceMetadata(directory, cacheId)
+    if (orderedSourcePages.isNotEmpty() && appearanceMetadata == null) return null
     val outputs = readOutputMetadata(directory, cacheId, orderedPages.size)
     val recent =
         RecentScan(
@@ -510,8 +786,22 @@ private fun readCacheEntry(
     return ParsedCacheEntry(
         directory = directory,
         recent = recent,
-        cached = CachedScan(cacheId, orderedPages, exactPdf, entryId = outputs?.entryId),
+        cached =
+            CachedScan(
+                cacheId,
+                orderedPages,
+                exactPdf,
+                entryId = outputs?.entryId,
+                sourcePages = orderedSourcePages,
+                appearance = appearanceMetadata?.appearance,
+                appearanceSettings = appearanceMetadata?.appearanceSettings,
+                pdfSizeTarget = appearanceMetadata?.pdfSizeTarget ?: PdfSizeTarget.Original,
+                lineageCacheId = appearanceMetadata?.lineageCacheId ?: cacheId,
+                parentCacheId = appearanceMetadata?.parentCacheId,
+                parentEntryId = appearanceMetadata?.parentEntryId,
+            ),
         outputs = outputs,
+        provisional = provisional,
     )
 }
 
@@ -590,14 +880,32 @@ private fun restoreRecoveryDirectory(
     moveEntry: (Path, Path) -> Unit,
 ) {
     val staged = recovery.listFiles() ?: throw IOException("Recent scan recovery could not be listed")
+    val activationMarker = staged.singleOrNull { it.name == ACTIVATION_ROLLBACK_MARKER }
+    if (
+        activationMarker != null &&
+            (
+                !isDirectChild(recovery, activationMarker.absoluteFile) ||
+                    !Files.isRegularFile(
+                        activationMarker.toPath(),
+                        LinkOption.NOFOLLOW_LINKS,
+                    ) ||
+                    activationMarker.length() != 0L
+            )
+    ) {
+        throw IOException("Activation recovery marker is unsafe")
+    }
     val entries =
-        staged.map { child ->
+        staged.filterNot { it.name == ACTIVATION_ROLLBACK_MARKER }.map { child ->
             val cacheId = child.name
             readCacheEntry(recovery, child.absoluteFile, cacheId)
                 ?: throw IOException("Recent scan recovery entry is incomplete")
         }
     val published = File(root, publishedCacheId).absoluteFile
-    if (published.exists()) {
+    val publishedIsProvisional =
+        readCacheEntry(root, published, publishedCacheId)?.provisional == true
+    if (activationMarker != null || publishedIsProvisional) {
+        ensureProvisionalCacheMarker(root, publishedCacheId)
+    } else if (published.exists()) {
         if (!deleteTreeWithoutFollowingLinks(published)) {
             throw IOException("Rolled-back recent scan could not be deleted")
         }
@@ -615,6 +923,22 @@ private fun restoreRecoveryDirectory(
     }
     if (!deleteTreeWithoutFollowingLinks(recovery)) {
         throw IOException("Recent scan recovery directory could not be removed")
+    }
+}
+
+private fun ensureProvisionalCacheMarker(root: File, cacheId: String) {
+    val directory = File(root, cacheId).absoluteFile
+    if (!directory.exists()) return
+    val current = readCacheEntry(root, directory, cacheId)
+        ?: throw IOException("Provisional cache recovery entry is incomplete")
+    if (current.provisional) return
+    val marker = File(directory, PROVISIONAL_CACHE_MARKER)
+    if (!marker.createNewFile()) {
+        throw IOException("Provisional cache marker could not be restored")
+    }
+    if (readCacheEntry(root, directory, cacheId)?.provisional != true) {
+        Files.deleteIfExists(marker.toPath())
+        throw IOException("Restored provisional cache entry is incomplete")
     }
 }
 
@@ -775,6 +1099,14 @@ internal class RecentScanCache(
             deleteRecentScanInRoot(root, cacheId)
         }
 
+    fun deleteExact(cacheId: String, entryId: String): Boolean =
+        lock.withLock {
+            if (!isSafeCacheId(cacheId) || !isCanonicalUuid(entryId)) return@withLock false
+            val current = openCachedScanInRoot(root, cacheId) ?: return@withLock false
+            if (current.entryId != entryId) return@withLock false
+            deleteRecentScanInRoot(root, cacheId)
+        }
+
     fun recoverPendingRemovals(): Boolean =
         lock.withLock {
             recoverPendingRecentRemovalsInRoot(root)
@@ -804,6 +1136,74 @@ internal class RecentScanCache(
                 moveEntry,
             )
         }
+
+    fun publishProvisional(
+        workDir: File,
+        finalDir: File,
+    ): CachedScan =
+        synchronized(lock) {
+            publishProvisionalCacheEntryInRoot(root, workDir, finalDir, moveEntry)
+        }
+
+    fun activateProvisional(
+        candidateCacheId: String,
+        retireCacheId: String? = null,
+        protectedCacheIds: Set<String> = emptySet(),
+        maxEntries: Int = MAX_SHARE_CACHE_SCANS,
+    ): CachedScan =
+        synchronized(lock) {
+            activateProvisionalCacheEntryInRoot(
+                root,
+                candidateCacheId,
+                retireCacheId,
+                protectedCacheIds,
+                maxEntries,
+                moveEntry,
+            )
+        }
+
+    fun isProvisional(cacheId: String): Boolean =
+        synchronized(lock) {
+            isProvisionalCacheEntryInRoot(root, cacheId)
+        }
+
+    fun deleteProvisional(cacheId: String, entryId: String): Boolean =
+        synchronized(lock) {
+            if (!isSafeCacheId(cacheId) || !isCanonicalUuid(entryId)) return@synchronized false
+            val safeRoot = ensureShareRoot(root)
+            maintainPendingDirectories(safeRoot)
+            val current =
+                readCacheEntry(
+                    safeRoot,
+                    File(safeRoot, cacheId).absoluteFile,
+                    cacheId,
+                ) ?: return@synchronized false
+            if (!current.provisional || current.cached.entryId != entryId) {
+                return@synchronized false
+            }
+            deleteRecentScanInRoot(safeRoot, cacheId)
+        }
+
+    fun reconcileProvisionals(authoritativeCacheId: String?) =
+        synchronized(lock) {
+            reconcileProvisionalCacheEntriesInRoot(
+                root,
+                authoritativeCacheId,
+            )
+        }
+
+    fun activateCheckpointProvisional(
+        candidateCacheId: String,
+        maxEntries: Int = MAX_SHARE_CACHE_SCANS,
+    ): CachedScan =
+        synchronized(lock) {
+            activateCheckpointProvisionalCacheEntryInRoot(
+                root,
+                candidateCacheId,
+                maxEntries,
+                moveEntry,
+            )
+        }
 }
 
 internal class ScanStorage(
@@ -814,10 +1214,17 @@ internal class ScanStorage(
     private val recentScanCache by lazy { RecentScanCache(shareCacheRoot(), storageTransactionLock) }
     private val outputDeleter by lazy { ExactOutputDeleter(context) }
 
-    fun cacheScan(pageUris: List<Uri>, pdfUri: Uri): CachedScan =
+    fun cacheScan(
+        pageUris: List<Uri>,
+        appearanceSettings: ScanAppearanceSettings,
+        pdfSizeTarget: PdfSizeTarget,
+        isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+    ): CachedScanBuild =
         storageTransactionLock.withLock {
             require(pageUris.isNotEmpty()) { "Scanner returned no pages" }
+            require(isAcceptedScanPageCount(pageUris.size)) { "Scanner returned too many pages" }
             val baseName = scanBaseName(clock)
+            val appearance = appearanceSettings.selected()
             val shareRoot = ensureShareRoot(shareCacheRoot())
             val finalDirectory = File(shareRoot, baseName)
             val workDirectory = File(shareRoot, ".pending-create-${UUID.randomUUID()}")
@@ -826,21 +1233,125 @@ internal class ScanStorage(
             }
 
             try {
-                pageUris.forEachIndexed { index, uri ->
-                    File(workDirectory, scanPageFileName(baseName, index + 1)).also {
-                        copyUriToFile(uri, it)
+                val sourcePages =
+                    pageUris.mapIndexed { index, uri ->
+                        File(workDirectory, scanSourcePageFileName(baseName, index + 1)).also {
+                            copyUriToFile(uri, it)
+                        }
                     }
-                }
-                File(workDirectory, scanPdfFileName(baseName)).also {
-                    copyUriToFile(pdfUri, it)
-                }
+                val renderedPages =
+                    sourcePages.mapIndexed { index, source ->
+                        File(workDirectory, scanPageFileName(baseName, index + 1)).also { destination ->
+                            ScanAppearanceRenderer.renderJpeg(
+                                source,
+                                destination,
+                                appearance,
+                                isCancelled = isCancelled,
+                            )
+                        }
+                    }
+                val pdfBuild =
+                    buildScanPdfFromPages(
+                        output = File(workDirectory, scanPdfFileName(baseName)),
+                        sourcePages = sourcePages,
+                        renderedPages = renderedPages,
+                        appearance = appearance,
+                        target = pdfSizeTarget,
+                        isCancelled = isCancelled,
+                    )
+                writeScanAppearanceMetadata(
+                    workDirectory,
+                    appearanceSettings,
+                    pdfSizeTarget,
+                    baseName,
+                )
                 initializeOutputMetadata(
                     directory = workDirectory,
                     cacheId = baseName,
                     pageCount = pageUris.size,
                     createdAtEpochMs = clock.millis(),
                 )
-                recentScanCache.publish(workDirectory, finalDirectory)
+                CachedScanBuild(
+                    cached = recentScanCache.publish(workDirectory, finalDirectory),
+                    pdf = pdfBuild,
+                )
+            } catch (failure: Throwable) {
+                deleteRecursivelyOrSuppress(workDirectory, failure)
+                throw failure
+            }
+        }
+
+    fun createAppearanceVariant(
+        source: CachedScan,
+        appearanceSettings: ScanAppearanceSettings,
+        pdfSizeTarget: PdfSizeTarget,
+        isCancelled: () -> Boolean = { Thread.currentThread().isInterrupted },
+    ): CachedScanBuild =
+        storageTransactionLock.withLock {
+            requireCurrentOutputMetadata(source)
+            if (
+                source.sourcePages.size != source.pages.size ||
+                    source.sourcePages.isEmpty() ||
+                    source.appearance == null ||
+                    source.entryId == null
+            ) {
+                throw IOException("Cached scan has no immutable appearance sources")
+            }
+            val appearance = appearanceSettings.selected()
+            val shareRoot = ensureShareRoot(shareCacheRoot())
+            val baseName =
+                recentScanCache.nextDerivedCacheId(source.lineageCacheId, "appearance")
+            val finalDirectory = File(shareRoot, baseName)
+            val workDirectory = File(shareRoot, ".pending-create-${UUID.randomUUID()}")
+            if (!workDirectory.mkdir()) {
+                throw IOException("Pending appearance cache directory could not be created")
+            }
+            try {
+                val sourcePages =
+                    source.sourcePages.mapIndexed { index, page ->
+                        File(workDirectory, scanSourcePageFileName(baseName, index + 1)).also {
+                            Files.createLink(it.toPath(), page.toPath())
+                        }
+                    }
+                val renderedPages =
+                    sourcePages.mapIndexed { index, page ->
+                        File(workDirectory, scanPageFileName(baseName, index + 1)).also { destination ->
+                            ScanAppearanceRenderer.renderJpeg(
+                                page,
+                                destination,
+                                appearance,
+                                isCancelled = isCancelled,
+                            )
+                        }
+                    }
+                val pdfBuild =
+                    buildScanPdfFromPages(
+                        output = File(workDirectory, scanPdfFileName(baseName)),
+                        sourcePages = sourcePages,
+                        renderedPages = renderedPages,
+                        appearance = appearance,
+                        target = pdfSizeTarget,
+                        isCancelled = isCancelled,
+                    )
+                writeScanAppearanceMetadata(
+                    workDirectory,
+                    appearanceSettings,
+                    pdfSizeTarget,
+                    source.lineageCacheId,
+                    parentCacheId = source.baseName,
+                    parentEntryId = source.entryId,
+                )
+                initializeOutputMetadata(
+                    directory = workDirectory,
+                    cacheId = baseName,
+                    pageCount = renderedPages.size,
+                    createdAtEpochMs = clock.millis(),
+                )
+                CachedScanBuild(
+                    cached =
+                        recentScanCache.publishProvisional(workDirectory, finalDirectory),
+                    pdf = pdfBuild,
+                )
             } catch (failure: Throwable) {
                 deleteRecursivelyOrSuppress(workDirectory, failure)
                 throw failure
@@ -888,6 +1399,7 @@ internal class ScanStorage(
                 galleryPages = outputs?.images?.map { it.uri.toUri() }.orEmpty(),
                 savedPdf = outputs?.pdf?.uri?.toUri(),
                 savedPdfTree = outputs?.pdf?.treeUri?.toUri(),
+                warnings = listOfNotNull(pdfSizeTargetWarning(cached.pdfSizeTarget, cached.pdf.length())),
                 outputMetadataValid = outputs != null,
                 savedPdfDeleteVerified = deleteMetadata?.pdf != null,
                 savedImagesDeleteVerified = deleteMetadata?.images?.isNotEmpty() == true,
@@ -895,7 +1407,9 @@ internal class ScanStorage(
         }
 
     fun deleteRecentScan(cacheId: String): Boolean =
-        recentScanCache.delete(cacheId)
+        storageTransactionLock.withLock {
+            recentScanCache.delete(cacheId)
+        }
 
     fun removeRecentPreview(request: OutputDeleteRequest): Boolean =
         storageTransactionLock.withLock {
@@ -906,6 +1420,12 @@ internal class ScanStorage(
         }
 
     fun deleteDurableOutputs(
+        request: OutputDeleteRequest,
+        deleteRecentCache: Boolean,
+    ): OutputDeleteOperationResult =
+        deleteDurableOutputsLocked(request, deleteRecentCache)
+
+    private fun deleteDurableOutputsLocked(
         request: OutputDeleteRequest,
         deleteRecentCache: Boolean,
     ): OutputDeleteOperationResult =
@@ -1016,7 +1536,9 @@ internal class ScanStorage(
         storageTransactionLock.withLock {
             val root = ensureShareRoot(shareCacheRoot())
             maintainPendingDirectories(root)
-            val entries = readCacheEntries(root).associateBy(ParsedCacheEntry::directory)
+            val entries =
+                readCacheEntries(root, includeProvisional = true)
+                    .associateBy(ParsedCacheEntry::directory)
             val children = root.listFiles() ?: throw IOException("Share cache could not be listed")
             completePdfTreeGrantInventory(
                 children.map { child ->
@@ -1038,27 +1560,56 @@ internal class ScanStorage(
     fun publishCacheEntry(
         workDir: File,
         finalDir: File,
+    ): CachedScan =
+        recentScanCache.publishProvisional(workDir, finalDir)
+
+    fun activateProvisionalCacheEntry(
+        candidate: CachedScan,
+        retireCacheId: String? = null,
         protectedCacheIds: Set<String> = emptySet(),
     ): CachedScan =
-        recentScanCache.publish(workDir, finalDir, protectedCacheIds)
+        storageTransactionLock.withLock {
+            requireCurrentOutputMetadata(candidate)
+            recentScanCache.activateProvisional(
+                candidate.baseName,
+                retireCacheId,
+                protectedCacheIds,
+            )
+        }
+
+    fun isProvisionalCacheEntry(candidate: CachedScan): Boolean =
+        storageTransactionLock.withLock {
+            requireCurrentOutputMetadata(candidate)
+            recentScanCache.isProvisional(candidate.baseName)
+        }
+
+    fun reconcileProvisionalCacheEntries(authoritative: CachedScan?) =
+        storageTransactionLock.withLock {
+            val authoritativeCacheId =
+                authoritative?.let { candidate ->
+                    requireCurrentOutputMetadata(candidate)
+                    candidate.baseName.takeIf { recentScanCache.isProvisional(it) }
+                }
+            recentScanCache.reconcileProvisionals(authoritativeCacheId)
+        }
+
+    fun deleteProvisionalCacheEntry(candidate: CachedScan): Boolean =
+        storageTransactionLock.withLock {
+            val metadata = requireCurrentOutputMetadata(candidate)
+            recentScanCache.deleteProvisional(candidate.baseName, metadata.entryId)
+        }
+
+    fun activateCheckpointProvisional(candidate: CachedScan): CachedScan =
+        storageTransactionLock.withLock {
+            requireCurrentOutputMetadata(candidate)
+            recentScanCache.activateCheckpointProvisional(candidate.baseName)
+        }
 
     fun deleteCachedScan(cached: CachedScan): Boolean =
         storageTransactionLock.withLock {
             try {
-                val root = shareCacheRoot()
-                val directory = File(root, cached.baseName).absoluteFile
-                if (
-                    directory.canonicalFile != directory ||
-                        directory.parentFile != root ||
-                        cached.pages.plus(cached.pdf).any {
-                            val file = it.absoluteFile
-                            file.canonicalFile != file || file.parentFile != directory
-                        }
-                ) {
-                    false
-                } else {
-                    !directory.exists() || deleteRecentScanInRoot(root, cached.baseName)
-                }
+                val entryId = cached.entryId ?: return@withLock false
+                recentScanCache.deleteExact(cached.baseName, entryId)
             } catch (_: IOException) {
                 false
             } catch (_: SecurityException) {
@@ -1082,9 +1633,10 @@ internal class ScanStorage(
                     return@withLock existing.map { it.uri.toUri() }
                 }
                 cached.pages.forEachIndexed { index, source ->
+                    val page = index + 1
                     val values =
                         pendingValues(
-                            scanPageFileName(cached.baseName, index + 1),
+                            scanPageFileName(cached.baseName, page),
                             JPEG_MIME_TYPE,
                             relativePath,
                         )
@@ -1241,7 +1793,14 @@ internal class ScanStorage(
         if (
             current.entryId != entryId ||
                 current.pdf != cached.pdf ||
-                current.pages != cached.pages
+                current.pages != cached.pages ||
+                current.sourcePages != cached.sourcePages ||
+                current.appearance != cached.appearance ||
+                current.appearanceSettings != cached.appearanceSettings ||
+                current.pdfSizeTarget != cached.pdfSizeTarget ||
+                current.lineageCacheId != cached.lineageCacheId ||
+                current.parentCacheId != cached.parentCacheId ||
+                current.parentEntryId != cached.parentEntryId
         ) {
             throw IOException("Cached scan belongs to another generation")
         }
@@ -1293,7 +1852,7 @@ internal class ScanStorage(
             if (
                 !DocumentsContract.isTreeUri(treeUri) ||
                     resolver.persistedUriPermissions.none {
-                        it.uri == treeUri && it.isWritePermission
+                        it.uri == treeUri && it.isReadPermission && it.isWritePermission
                     }
             ) {
                 return null to false
@@ -1304,9 +1863,15 @@ internal class ScanStorage(
                     DocumentsContract.getTreeDocumentId(treeUri),
                 )
             val document =
-                DocumentsContract.createDocument(resolver, parent, PDF_MIME_TYPE, displayName)
+                DocumentsContract.createDocument(
+                    resolver,
+                    parent,
+                    PDF_MIME_TYPE,
+                    displayName,
+                )
                     ?: return null to false
             createdDocument = document
+            if (!isCreatedSafChild(treeUri, document)) return null to true
             copyFileToUri(source, document)
             if (fingerprintFile(source) != sourceFingerprint) {
                 throw IOException("Source file changed while it was copied")
@@ -1338,16 +1903,11 @@ internal class ScanStorage(
     }
 
     private fun readSafPdfDisplayName(tree: Uri, document: Uri): String {
-        val rootId = DocumentsContract.getTreeDocumentId(tree)
-        val documentId = DocumentsContract.getDocumentId(document)
-        if (
-            tree.authority != document.authority ||
-                rootId == documentId ||
-                DocumentsContract.getTreeDocumentId(document) != rootId ||
-                DocumentsContract.buildDocumentUriUsingTree(tree, documentId) != document
-        ) {
+        if (!isCreatedSafChild(tree, document)) {
             throw IOException("Created SAF document identity is unsafe")
         }
+        val rootId = DocumentsContract.getTreeDocumentId(tree)
+        val documentId = DocumentsContract.getDocumentId(document)
         val cursor =
             resolver.query(
                 document,
@@ -1387,6 +1947,28 @@ internal class ScanStorage(
             actualName
         }
     }
+
+    private fun isCreatedSafChild(tree: Uri, document: Uri): Boolean =
+        try {
+            val rootId = DocumentsContract.getTreeDocumentId(tree)
+            val documentId = DocumentsContract.getDocumentId(document)
+            val rootDocument = DocumentsContract.buildDocumentUriUsingTree(tree, rootId)
+            safChildStructureIsValid(
+                sameAuthority =
+                    document.scheme == ContentResolver.SCHEME_CONTENT &&
+                        tree.authority != null &&
+                        tree.authority == document.authority,
+                rootDocumentId = rootId,
+                returnedTreeDocumentId = DocumentsContract.getTreeDocumentId(document),
+                returnedDocumentId = documentId,
+                returnedUriIsCanonical =
+                    document.query == null &&
+                        document.fragment == null &&
+                        DocumentsContract.buildDocumentUriUsingTree(tree, documentId) == document,
+            ) && DocumentsContract.isChildDocument(resolver, rootDocument, document)
+        } catch (_: Exception) {
+            false
+        }
 
     private fun pendingValues(displayName: String, mimeType: String, relativePath: String) =
         ContentValues().apply {

--- a/app/src/main/java/com/majkeylab/scanit/ScanViewModel.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -36,6 +37,16 @@ private const val RESULT_PREVIEW_SIZE = 1024
 private const val PAGE_THUMBNAIL_SIZE = 256
 internal const val PDF_TREE_FLAGS =
     Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+
+internal fun pdfSizeTargetWarning(result: ScanPdfBuildResult): UiMessage {
+    require(!result.targetMet && result.bytes > 0L) { "PDF warning requires an unmet target" }
+    return requireNotNull(pdfSizeTargetWarning(result.target, result.bytes)) {
+        "PDF warning requires an exceeded size target"
+    }
+}
+
+internal fun settingsSaveAllowed(state: ScreenState): Boolean =
+    (state as? ScreenState.Result)?.appearanceApplyInProgress != true
 
 internal fun scannerPreparationMayResume(
     navigationInitialized: Boolean,
@@ -193,14 +204,61 @@ private enum class CheckpointMutationResult {
 
 private data class CheckpointReadResult(
     val mutation: CheckpointMutationResult,
-    val cacheId: String? = null,
+    val checkpoint: ActiveResultCheckpoint? = null,
+    val authoritativeWasProvisional: Boolean = false,
 )
+
+internal class ActiveResultCleanupException(cause: Exception) :
+    IOException("Active result was cleared but provisional cleanup failed", cause)
+
+internal fun clearActiveResultAndReconcileProvisionals(
+    clearCheckpoint: () -> AuthorityMutationResult,
+    reconcileProvisionals: () -> Unit,
+): AuthorityMutationResult =
+    withActiveResultAuthority {
+        val cleared = clearCheckpoint()
+        if (cleared != AuthorityMutationResult.Applied) {
+            return@withActiveResultAuthority cleared
+        }
+        try {
+            reconcileProvisionals()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Exception) {
+            throw ActiveResultCleanupException(failure)
+        }
+        AuthorityMutationResult.Applied
+    }
+
+internal fun keepCheckpointAfterRestoreFailure(authoritativeWasProvisional: Boolean): Boolean =
+    authoritativeWasProvisional
+
+internal fun checkpointRestoreSettings(
+    current: AppSettings,
+    authoritative: CachedScan?,
+    provisional: Boolean,
+): AppSettings {
+    if (!provisional) return current
+    val cached = checkNotNull(authoritative)
+    return current.copy(
+        appearance = checkNotNull(cached.appearanceSettings),
+        pdfSizeTarget = cached.pdfSizeTarget,
+    )
+}
 
 private data class OutputSaveResult(
     val scan: SavedScan?,
     val successful: Set<SavedOutputKind>,
     val warnings: List<UiMessage>,
 )
+
+internal fun automaticOutputTarget(settings: AppSettings): SaveNowTarget? =
+    when {
+        settings.savePdf && settings.saveImages -> SaveNowTarget.Both
+        settings.savePdf -> SaveNowTarget.Pdf
+        settings.saveImages -> SaveNowTarget.Images
+        else -> null
+    }
 
 private enum class ResultActivation {
     Applied,
@@ -251,9 +309,12 @@ internal class ScanViewModel(
     private var recentJob: Job? = null
     private var cacheRefreshJob: Job? = null
     private var outputSaveJob: Job? = null
+    private var appearanceApplyJob: Job? = null
     private var resultPreviewJob: Job? = null
     private var recentScans: List<RecentScan> = emptyList()
     private var navigationInitialized = false
+    private var activeResultAuthorityKnown = false
+    private var activeResultOwner: ActiveResultOwner? = null
 
     val state: StateFlow<ScreenState> = mutableState.asStateFlow()
     val scannerRequest: StateFlow<Long?> = mutableScannerRequest.asStateFlow()
@@ -327,18 +388,30 @@ internal class ScanViewModel(
         val localized =
             localizedDefaultEmailSubject(current.emailSubject, targetDefault, supportedDefaults)
         if (localized != current.emailSubject) {
-            saveSettings(current.copy(emailSubject = localized))
+            settingsStore.saveEmailSubject(localized)
+            mutableSettings.value = mutableSettings.value.copy(emailSubject = localized)
         }
     }
 
-    fun saveSettings(settings: AppSettings) {
+    fun saveSettings(settings: AppSettings): Boolean {
+        if (!settingsSaveAllowed(mutableState.value) || !activeResultAuthorityKnown) return false
+        val owner = activeResultOwner ?: return false
         val normalized =
             settings.copy(
                 albumName = normalizeAlbumName(settings.albumName),
                 pdfTreeUri = mutableSettings.value.pdfTreeUri,
             )
-        settingsStore.save(normalized)
+        val saved =
+            try {
+                settingsStore.trySave(normalized, owner)
+            } catch (_: IOException) {
+                return false
+            } catch (_: RuntimeException) {
+                return false
+            }
+        if (!settingsSaveApplied(saved)) return false
         mutableSettings.value = normalized
+        return true
     }
 
     fun setPdfTreeUri(uri: Uri, grantedFlags: Int): UiMessage? =
@@ -451,8 +524,12 @@ internal class ScanViewModel(
         }
     }
 
-    fun processScan(pageUris: List<Uri>, pdfUri: Uri): Boolean {
+    fun processScan(pageUris: List<Uri>): Boolean {
         completeScannerLaunch()
+        if (!isAcceptedScanPageCount(pageUris.size)) {
+            scannerResultFailed(UiMessage(R.string.scanner_result_error))
+            return false
+        }
         if (processingJob?.isActive == true) {
             mutableState.value =
                 ScreenState.Processing(
@@ -480,7 +557,15 @@ internal class ScanViewModel(
                     val result =
                         withContext(Dispatchers.IO) {
                             val settings = currentSettings()
-                            val cachedScan = storage.cacheScan(pages, pdfUri)
+                            val processingContext = currentCoroutineContext()
+                            val cacheBuild =
+                                storage.cacheScan(
+                                    pageUris = pages,
+                                    appearanceSettings = settings.appearance,
+                                    pdfSizeTarget = settings.pdfSizeTarget,
+                                    isCancelled = { !processingContext.isActive },
+                                )
+                            val cachedScan = cacheBuild.cached
                             cached = cachedScan
                             val thumbnail =
                                 storage.loadThumbnail(
@@ -488,6 +573,9 @@ internal class ScanViewModel(
                                     RESULT_PREVIEW_SIZE,
                                 )
                             val warnings = mutableListOf<UiMessage>()
+                            if (!cacheBuild.pdf.targetMet) {
+                                warnings += pdfSizeTargetWarning(cacheBuild.pdf)
+                            }
                             if (settings.saveImages) {
                                 try {
                                     galleryPages =
@@ -504,10 +592,9 @@ internal class ScanViewModel(
                             if (settings.savePdf) {
                                 try {
                                     val savedPdf =
-                                        storage.savePdf(
+                                        savePdfToCanonicalDestination(
                                             cachedScan,
                                             settings.albumName,
-                                            settings.pdfTreeUri,
                                         )
                                     savedPdfUri = savedPdf.uri
                                     savedPdfTreeUri = savedPdf.treeUri
@@ -616,7 +703,7 @@ internal class ScanViewModel(
 
     fun selectResultPage(selectedPageIndex: Int) {
         val current = mutableState.value as? ScreenState.Result ?: return
-        if (current.outputSaveInProgress) return
+        if (current.outputSaveInProgress || current.appearanceApplyInProgress) return
         val pageIndex = resolvedPageIndex(selectedPageIndex, current.scan.cached.pages.size)
         if (
             pageIndex == current.selectedPageIndex &&
@@ -670,8 +757,192 @@ internal class ScanViewModel(
             }
     }
 
+    fun applyCurrentAppearance(requested: ScanAppearanceSettings) {
+        val current = mutableState.value as? ScreenState.Result ?: return
+        val cached = current.scan.cached
+        if (
+            current.outputSaveInProgress ||
+                current.appearanceApplyInProgress ||
+                current.pagePreviewLoading ||
+                appearanceApplyJob?.isActive == true ||
+                cached.sourcePages.size != cached.pages.size ||
+                cached.appearance == null ||
+                cached.entryId == null ||
+                !current.scan.outputMetadataValid
+        ) {
+            return
+        }
+        val previousSettings = currentSettings()
+        val normalized =
+            parseScanAppearanceSettings(
+                colorModeWireValue = requested.colorMode.wireValue,
+                colorIntensity = requested.colorIntensity,
+                grayscaleIntensity = requested.grayscaleIntensity,
+                blackWhiteIntensity = requested.blackWhiteIntensity,
+                shadows = requested.shadows,
+            )
+        if (
+            cached.appearanceSettings == normalized &&
+                cached.pdfSizeTarget == previousSettings.pdfSizeTarget
+        ) {
+            return
+        }
+        val generation = beginRouteMutation()
+        mutableState.value =
+            current.copy(
+                appearanceApplyInProgress = true,
+                appearanceMessage = null,
+            )
+        appearanceApplyJob =
+            viewModelScope.launch {
+                var created: CachedScan? = null
+                var checkpointCommitted = false
+                var pageIndex = current.selectedPageIndex
+                var thumbnail = current.thumbnail
+                var buildWarnings: List<UiMessage> = emptyList()
+                try {
+                    withContext(Dispatchers.IO) {
+                        val coroutineContext = currentCoroutineContext()
+                        val build =
+                            storage.createAppearanceVariant(
+                                source = cached,
+                                appearanceSettings = normalized,
+                                pdfSizeTarget = previousSettings.pdfSizeTarget,
+                                isCancelled = { !coroutineContext.isActive },
+                            )
+                        created = build.cached
+                        buildWarnings =
+                            if (build.pdf.targetMet) {
+                                emptyList()
+                            } else {
+                                listOf(pdfSizeTargetWarning(build.pdf))
+                            }
+                        pageIndex =
+                            resolvedPageIndex(
+                                current.selectedPageIndex,
+                                build.cached.pages.size,
+                            )
+                        thumbnail =
+                            storage.loadThumbnail(
+                                build.cached.pages[pageIndex],
+                                RESULT_PREVIEW_SIZE,
+                            )
+                    }
+                    val completed =
+                        routeMutationMutex.withLock {
+                            val latest = mutableState.value as? ScreenState.Result
+                            if (
+                                !routeMutationGate.isCurrent(generation) ||
+                                    latest?.scan?.cached?.baseName != cached.baseName ||
+                                    latest.scan.cached.entryId != cached.entryId
+                            ) {
+                                return@withLock false
+                            }
+                            val candidate = checkNotNull(created)
+                            val commitResult =
+                                withContext(NonCancellable + Dispatchers.IO) {
+                                    commitAppliedAppearance(
+                                        normalized = normalized,
+                                        pdfSizeTarget = previousSettings.pdfSizeTarget,
+                                        targetCacheId = candidate.baseName,
+                                    )
+                                }
+                            if (commitResult != AppearanceCommitResult.Applied) {
+                                return@withLock false
+                            }
+                            checkpointCommitted = true
+                            mutableSettings.value =
+                                mutableSettings.value.copy(
+                                    appearance = normalized,
+                                    pdfSizeTarget = previousSettings.pdfSizeTarget,
+                                )
+                            val saved =
+                                withContext(NonCancellable + Dispatchers.IO) {
+                                    completeAppearanceCandidate(candidate, buildWarnings)
+                                }
+                            if (routeMutationGate.isCurrent(generation)) {
+                                publishResult(
+                                    ScreenState.Result(
+                                        scan = saved,
+                                        thumbnail = thumbnail,
+                                        selectedPageIndex = pageIndex,
+                                    ),
+                                )
+                            }
+                            true
+                        }
+                    if (!completed && !checkpointCommitted) {
+                        created?.let { discardAppearanceVariantUnlessActive(it) }
+                        if (routeMutationGate.isCurrent(generation)) {
+                            val latest = mutableState.value as? ScreenState.Result
+                            if (
+                                latest?.scan?.cached?.baseName == cached.baseName &&
+                                    latest.scan.cached.entryId == cached.entryId
+                            ) {
+                                mutableState.value =
+                                    latest.copy(
+                                        appearanceApplyInProgress = false,
+                                        appearanceMessage =
+                                            UiMessage(R.string.appearance_apply_failed),
+                                    )
+                            }
+                        }
+                    }
+                } catch (cancellation: CancellationException) {
+                    if (!checkpointCommitted) {
+                        created?.let { discardAppearanceVariantUnlessActive(it) }
+                    }
+                    throw cancellation
+                } catch (_: Exception) {
+                    if (checkpointCommitted) {
+                        val recovered =
+                            try {
+                                withContext(NonCancellable + Dispatchers.IO) {
+                                    created?.let {
+                                        completeAppearanceCandidate(
+                                            it,
+                                            buildWarnings + UiMessage(R.string.state_update_failed),
+                                        )
+                                    }
+                                }
+                            } catch (_: Exception) {
+                                null
+                            }
+                        routeMutationMutex.withLock {
+                            if (routeMutationGate.isCurrent(generation) && recovered != null) {
+                                publishResult(
+                                    ScreenState.Result(
+                                        scan = recovered,
+                                        thumbnail = thumbnail,
+                                        selectedPageIndex = pageIndex,
+                                    ),
+                                )
+                            } else if (routeMutationGate.isCurrent(generation)) {
+                                navigationInitialized = true
+                                persistRoute(ROUTE_FAILURE)
+                                mutableState.value =
+                                    ScreenState.Failure(UiMessage(R.string.state_update_failed))
+                            }
+                        }
+                    } else {
+                        created?.let { discardAppearanceVariantUnlessActive(it) }
+                        if (routeMutationGate.isCurrent(generation)) {
+                            mutableState.value =
+                                current.copy(
+                                    appearanceApplyInProgress = false,
+                                    appearanceMessage =
+                                        UiMessage(R.string.appearance_apply_failed),
+                                )
+                        }
+                    }
+                }
+            }
+    }
+
+
     fun saveCurrentOutputs(target: SaveNowTarget) {
         val current = mutableState.value as? ScreenState.Result ?: return
+        if (current.appearanceApplyInProgress) return
         val entryId = current.scan.cached.entryId ?: return
         if (target !in saveNowTargets(current.scan)) return
         val action = resultSaveGate.begin(current.scan.cached.baseName, entryId) ?: return
@@ -895,12 +1166,32 @@ internal class ScanViewModel(
             viewModelScope.launch {
                 val checkpoint = readActiveResultCheckpoint(generation)
                 if (checkpoint.mutation != CheckpointMutationResult.Applied) return@launch
-                val destination = initialNavigation(savedRoute, savedCacheId, checkpoint.cacheId)
+                val activeCheckpoint = checkpoint.checkpoint
+                val authoritativeWasProvisional = checkpoint.authoritativeWasProvisional
+                val destination =
+                    initialNavigation(savedRoute, savedCacheId, activeCheckpoint?.cacheId)
                 when (destination.route) {
                     RestoredRoute.Result -> {
                         val cacheId = checkNotNull(destination.cacheId)
                         val result = loadCachedResult(cacheId)
                         if (result == null) {
+                            if (
+                                keepCheckpointAfterRestoreFailure(
+                                    authoritativeWasProvisional,
+                                )
+                            ) {
+                                routeMutationMutex.withLock {
+                                    if (routeMutationGate.isCurrent(generation)) {
+                                        navigationInitialized = true
+                                        persistRoute(ROUTE_FAILURE)
+                                        mutableState.value =
+                                            ScreenState.Failure(
+                                                UiMessage(R.string.state_update_failed),
+                                            )
+                                    }
+                                }
+                                return@launch
+                            }
                             if (
                                 clearCheckpointAndPublish(generation) {
                                     navigationInitialized = true
@@ -953,7 +1244,14 @@ internal class ScanViewModel(
         val savedPageIndex = savedStateHandle.get<Int>(RESULT_PAGE_INDEX_KEY)
         return try {
             withContext(Dispatchers.IO) {
-                val saved = storage.openSavedScan(cacheId) ?: return@withContext null
+                var saved = storage.openSavedScan(cacheId) ?: return@withContext null
+                if (storage.isProvisionalCacheEntry(saved.cached)) {
+                    saved =
+                        completeAppearanceCandidate(
+                            candidate = saved.cached,
+                            initialWarnings = saved.warnings,
+                        )
+                }
                 val pageIndex =
                     restoredResultPageIndex(
                         savedCacheId = savedResultCacheId,
@@ -987,7 +1285,15 @@ internal class ScanViewModel(
         routeMutationMutex.withLock {
             if (!routeMutationGate.isCurrent(generation)) return@withLock ResultActivation.Stale
             try {
-                withContext(Dispatchers.IO) { settingsStore.saveActiveResult(cacheId) }
+                val owner = activeResultOwner ?: return@withLock ResultActivation.Stale
+                val saved =
+                    withContext(Dispatchers.IO) {
+                        settingsStore.saveActiveResult(cacheId, owner)
+                    }
+                if (saved != AuthorityMutationResult.Applied) {
+                    return@withLock ResultActivation.Stale
+                }
+                activeResultOwner = owner.withCheckpoint(ActiveResultCheckpoint(cacheId))
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (_: IOException) {
@@ -1006,8 +1312,15 @@ internal class ScanViewModel(
     ): ResultActivation {
         val cleared =
             try {
-                withContext(Dispatchers.IO) { settingsStore.clearActiveResult() }
-                true
+                val owner = activeResultOwner ?: return ResultActivation.Stale
+                val result =
+                    withContext(Dispatchers.IO) {
+                        settingsStore.clearActiveResult(owner)
+                    }
+                if (result == AuthorityMutationResult.Applied) {
+                    activeResultOwner = owner.withCheckpoint(null)
+                }
+                result == AuthorityMutationResult.Applied
             } catch (_: IOException) {
                 false
             }
@@ -1088,6 +1401,7 @@ internal class ScanViewModel(
     }
 
     private fun beginRouteMutation(): Long {
+        appearanceApplyJob?.cancel()
         resultSaveGate.invalidate()
         outputSaveJob?.cancel()
         recentActionGate.invalidate()
@@ -1097,11 +1411,54 @@ internal class ScanViewModel(
         return routeMutationGate.begin()
     }
 
+    private suspend fun discardAppearanceVariantUnlessActive(variant: CachedScan) {
+        withContext(NonCancellable + Dispatchers.IO) {
+            val isActive =
+                try {
+                    settingsStore.activeResultCacheId() == variant.baseName
+                } catch (_: IOException) {
+                    true
+                } catch (_: RuntimeException) {
+                    true
+                }
+            if (!isActive) {
+                try {
+                    storage.deleteProvisionalCacheEntry(variant)
+                } catch (_: IOException) {
+                    // Keep an ambiguous candidate for startup reconciliation.
+                } catch (_: SecurityException) {
+                    // Keep an ambiguous candidate for startup reconciliation.
+                } catch (_: IllegalArgumentException) {
+                    // Keep an ambiguous candidate for startup reconciliation.
+                }
+            }
+        }
+    }
+
+    private fun commitAppliedAppearance(
+        normalized: ScanAppearanceSettings,
+        pdfSizeTarget: PdfSizeTarget,
+        targetCacheId: String,
+    ): AppearanceCommitResult {
+        val owner = activeResultOwner ?: return AppearanceCommitResult.Stale
+        val result =
+            settingsStore.saveAppliedAppearanceAndActiveResult(
+                normalized,
+                pdfSizeTarget,
+                targetCacheId,
+                owner,
+            )
+        if (result == AppearanceCommitResult.Applied) {
+            activeResultOwner = owner.withCheckpoint(ActiveResultCheckpoint(targetCacheId))
+        }
+        return result
+    }
+
     private suspend fun saveCurrentOutputs(
         scan: SavedScan,
         target: SaveNowTarget,
+        settings: AppSettings = currentSettings(),
     ): OutputSaveResult {
-        val settings = currentSettings()
         val successful = mutableSetOf<SavedOutputKind>()
         val warnings = mutableListOf<UiMessage>()
         if (target == SaveNowTarget.Images || target == SaveNowTarget.Both) {
@@ -1119,8 +1476,7 @@ internal class ScanViewModel(
         currentCoroutineContext().ensureActive()
         if (target == SaveNowTarget.Pdf || target == SaveNowTarget.Both) {
             try {
-                val saved =
-                    storage.savePdf(scan.cached, settings.albumName, settings.pdfTreeUri)
+                val saved = savePdfToCanonicalDestination(scan.cached, settings.albumName)
                 successful += SavedOutputKind.Pdf
                 saved.warning?.let(warnings::add)
             } catch (cancellation: CancellationException) {
@@ -1144,17 +1500,101 @@ internal class ScanViewModel(
         )
     }
 
+    private fun savePdfToCanonicalDestination(
+        cached: CachedScan,
+        albumName: String,
+    ): SavedPdfOutput =
+        withStorageTransaction {
+            storage.savePdf(cached, albumName, canonicalPdfTreeUri(settingsStore))
+        }
+
+    private suspend fun completeAppearanceCandidate(
+        candidate: CachedScan,
+        initialWarnings: List<UiMessage>,
+    ): SavedScan {
+        val owner = activeResultOwner
+            ?: throw IOException("Active result authority is unavailable")
+        val activated =
+            withActiveResultAuthority {
+                if (!settingsStore.ownsActiveResult(owner)) {
+                    throw IOException("Active result checkpoint ownership changed")
+                }
+                if (storage.isProvisionalCacheEntry(candidate)) {
+                    val appearance = candidate.appearanceSettings
+                        ?: throw IOException("Appearance authority metadata is unavailable")
+                    if (
+                        settingsStore.restoreAppearanceAuthority(
+                            appearance,
+                            candidate.pdfSizeTarget,
+                            owner,
+                        ) != AuthorityMutationResult.Applied
+                    ) {
+                        throw IOException("Appearance authority could not be repaired")
+                    }
+                    storage.activateCheckpointProvisional(candidate)
+                } else {
+                    candidate
+                }
+            }
+        val saved =
+            storage.openSavedScan(activated.baseName)
+                ?: throw IOException("Cached scan output metadata is unavailable")
+        return saved.copy(warnings = (initialWarnings + saved.warnings).distinct())
+    }
+
     private suspend fun readActiveResultCheckpoint(generation: Long): CheckpointReadResult =
         routeMutationMutex.withLock {
             if (!routeMutationGate.isCurrent(generation)) {
                 return@withLock CheckpointReadResult(CheckpointMutationResult.Stale)
             }
-            val cacheId =
+            val restored =
                 try {
-                    withContext(Dispatchers.IO) { settingsStore.activeResultCacheId() }
+                    withContext(Dispatchers.IO) {
+                        settingsStore.withAuthoritySnapshot { snapshot ->
+                            val checkpoint = snapshot.checkpoint
+                            val authoritative =
+                                checkpoint?.cacheId?.let(storage::openCachedScan)
+                            val provisional =
+                                authoritative?.let(storage::isProvisionalCacheEntry) == true
+                            if (
+                                provisional &&
+                                    (authoritative.appearanceSettings == null ||
+                                        authoritative.parentCacheId == null ||
+                                        authoritative.parentEntryId == null)
+                            ) {
+                                throw IOException(
+                                    "Provisional checkpoint metadata is not authoritative",
+                                )
+                            }
+                            val effectiveSettings =
+                                checkpointRestoreSettings(
+                                    snapshot.settings,
+                                    authoritative,
+                                    provisional,
+                                )
+                            if (provisional) {
+                                    if (
+                                        settingsStore.restoreAppearanceAuthority(
+                                            effectiveSettings.appearance,
+                                            effectiveSettings.pdfSizeTarget,
+                                            snapshot.owner,
+                                        ) != AuthorityMutationResult.Applied
+                                    ) {
+                                        throw IOException("Appearance authority changed")
+                                    }
+                            }
+                            storage.reconcileProvisionalCacheEntries(authoritative)
+                            ActiveResultAuthoritySnapshot(
+                                effectiveSettings,
+                                checkpoint,
+                                snapshot.owner,
+                            ) to
+                                provisional
+                        }
+                    }
                 } catch (cancellation: CancellationException) {
                     throw cancellation
-                } catch (_: IOException) {
+                } catch (_: Exception) {
                     if (routeMutationGate.isCurrent(generation)) {
                         persistRoute(ROUTE_FAILURE)
                         mutableState.value =
@@ -1165,7 +1605,15 @@ internal class ScanViewModel(
             if (!routeMutationGate.isCurrent(generation)) {
                 CheckpointReadResult(CheckpointMutationResult.Stale)
             } else {
-                CheckpointReadResult(CheckpointMutationResult.Applied, cacheId)
+                val (snapshot, provisional) = restored
+                activeResultOwner = snapshot.owner
+                activeResultAuthorityKnown = true
+                mutableSettings.value = snapshot.settings
+                CheckpointReadResult(
+                    mutation = CheckpointMutationResult.Applied,
+                    checkpoint = snapshot.checkpoint,
+                    authoritativeWasProvisional = provisional,
+                )
             }
         }
 
@@ -1181,10 +1629,37 @@ internal class ScanViewModel(
             if (!routeMutationGate.isCurrent(generation)) {
                 return@withLock CheckpointMutationResult.Stale
             }
+            val owner = activeResultOwner
+                ?: return@withLock CheckpointMutationResult.Stale
             try {
-                withContext(Dispatchers.IO) { settingsStore.clearActiveResult() }
+                val cleanup =
+                    withContext(NonCancellable + Dispatchers.IO) {
+                        clearActiveResultAndReconcileProvisionals(
+                            clearCheckpoint = {
+                                val result = settingsStore.clearActiveResult(owner)
+                                if (result == AuthorityMutationResult.Applied) {
+                                    activeResultOwner = owner.withCheckpoint(null)
+                                }
+                                result
+                            },
+                            reconcileProvisionals = {
+                                storage.reconcileProvisionalCacheEntries(null)
+                            },
+                        )
+                    }
+                if (cleanup != AuthorityMutationResult.Applied) {
+                    return@withLock CheckpointMutationResult.Stale
+                }
             } catch (cancellation: CancellationException) {
                 throw cancellation
+            } catch (_: ActiveResultCleanupException) {
+                if (!routeMutationGate.isCurrent(generation)) {
+                    return@withLock CheckpointMutationResult.Stale
+                }
+                navigationInitialized = true
+                persistRoute(ROUTE_FAILURE)
+                mutableState.value = ScreenState.Failure(UiMessage(R.string.state_update_failed))
+                return@withLock CheckpointMutationResult.Failed
             } catch (_: IOException) {
                 if (!routeMutationGate.isCurrent(generation)) {
                     return@withLock CheckpointMutationResult.Stale
@@ -1259,6 +1734,7 @@ internal class ScanViewModel(
                 current = current,
                 pending = null,
             )
+            mutableSettings.value = mutableSettings.value.copy(pdfTreeUri = current)
             null
         } catch (_: IOException) {
             UiMessage(R.string.pdf_tree_release_warning)

--- a/app/src/main/java/com/majkeylab/scanit/SettingsStore.kt
+++ b/app/src/main/java/com/majkeylab/scanit/SettingsStore.kt
@@ -17,12 +17,20 @@ private const val KEY_EMAIL_SUBJECT = "email_subject"
 private const val KEY_EMAIL_BODY = "email_body"
 private const val KEY_DELETE_PDF_AFTER_SHARE = "delete_pdf_after_share"
 private const val KEY_DELETE_IMAGES_AFTER_SHARE = "delete_images_after_share"
+private const val KEY_APPEARANCE_MODE = "appearance_mode"
+private const val KEY_APPEARANCE_COLOR_INTENSITY = "appearance_color_intensity"
+private const val KEY_APPEARANCE_GRAYSCALE_INTENSITY = "appearance_grayscale_intensity"
+private const val KEY_APPEARANCE_BLACK_WHITE_INTENSITY = "appearance_black_white_intensity"
+private const val KEY_APPEARANCE_SHADOWS = "appearance_shadows"
+private const val KEY_PDF_SIZE_TARGET = "pdf_size_target"
 private const val KEY_PDF_TREE_URI = "pdf_tree_uri"
 private const val KEY_PENDING_PDF_TREE_URI = "pending_pdf_tree_uri"
 private const val KEY_ACTIVE_RESULT_CHECKPOINT = "active_result_checkpoint"
 private const val KEY_PENDING_SHARE_CLEANUP = "pending_share_cleanup"
-private const val ACTIVE_RESULT_CHECKPOINT_PREFIX = "1:"
+private const val ACTIVE_RESULT_CHECKPOINT_V1_PREFIX = "1:"
+private const val ACTIVE_RESULT_CHECKPOINT_V2_PREFIX = "2:"
 private const val MAX_ACTIVE_RESULT_CACHE_ID_LENGTH = 128
+private const val MAX_ACTIVE_RESULT_CHECKPOINT_LENGTH = 192
 private const val PENDING_SHARE_CLEANUP_PREFIX = "1:"
 private const val CANONICAL_UUID_LENGTH = 36
 private const val MAX_SHARE_CLEANUP_KIND_LENGTH = 6
@@ -34,6 +42,45 @@ private const val MAX_PENDING_SHARE_CLEANUP_LENGTH =
 internal const val MAX_PENDING_SHARE_CLEANUPS = 8
 private val shareCleanupQueueLock = ReentrantLock()
 
+private val ACTIVE_RESULT_AUTHORITY_LOCK = ReentrantLock()
+private var activeResultAuthorityRevision = 0L
+
+internal fun <T> withActiveResultAuthority(block: () -> T): T =
+    ACTIVE_RESULT_AUTHORITY_LOCK.withLock(block)
+
+internal enum class AuthorityMutationResult {
+    Applied,
+    Stale,
+    Busy,
+}
+
+internal fun settingsSaveApplied(result: AuthorityMutationResult): Boolean =
+    result == AuthorityMutationResult.Applied
+
+internal enum class AppearanceCommitResult {
+    Applied,
+    NotApplied,
+    Stale,
+}
+
+internal data class ActiveResultCheckpoint(
+    val cacheId: String,
+)
+
+internal data class ActiveResultOwner(
+    val revision: Long,
+    val checkpoint: ActiveResultCheckpoint?,
+) {
+    fun withCheckpoint(checkpoint: ActiveResultCheckpoint?): ActiveResultOwner =
+        copy(checkpoint = checkpoint)
+}
+
+internal data class ActiveResultAuthoritySnapshot(
+    val settings: AppSettings,
+    val checkpoint: ActiveResultCheckpoint?,
+    val owner: ActiveResultOwner,
+)
+
 internal fun isSafeActiveResultCacheId(cacheId: String): Boolean =
     cacheId.length <= MAX_ACTIVE_RESULT_CACHE_ID_LENGTH && isSafeCacheId(cacheId)
 
@@ -41,20 +88,25 @@ internal fun encodeActiveResultCheckpoint(cacheId: String): String {
     require(isSafeActiveResultCacheId(cacheId)) {
         "Active result cache ID is unsafe"
     }
-    return "$ACTIVE_RESULT_CHECKPOINT_PREFIX$cacheId"
+    return "$ACTIVE_RESULT_CHECKPOINT_V1_PREFIX$cacheId"
 }
 
-internal fun decodeActiveResultCheckpoint(value: String?): String? {
-    if (
-        value == null ||
-            value.length >
-            ACTIVE_RESULT_CHECKPOINT_PREFIX.length + MAX_ACTIVE_RESULT_CACHE_ID_LENGTH ||
-            !value.startsWith(ACTIVE_RESULT_CHECKPOINT_PREFIX)
-    ) {
-        return null
+internal fun decodeActiveResultCheckpointPayload(value: String?): ActiveResultCheckpoint? {
+    if (value == null || value.length > MAX_ACTIVE_RESULT_CHECKPOINT_LENGTH) return null
+    if (value.startsWith(ACTIVE_RESULT_CHECKPOINT_V1_PREFIX)) {
+        val cacheId = value.removePrefix(ACTIVE_RESULT_CHECKPOINT_V1_PREFIX)
+        return cacheId.takeIf(::isSafeActiveResultCacheId)?.let {
+            ActiveResultCheckpoint(it)
+        }
     }
-    return value.removePrefix(ACTIVE_RESULT_CHECKPOINT_PREFIX)
-        .takeIf(::isSafeActiveResultCacheId)
+    if (!value.startsWith(ACTIVE_RESULT_CHECKPOINT_V2_PREFIX)) return null
+    val fields = value.split(':')
+    if (fields.size != 7 || fields[0] != "2") return null
+    val cacheId = fields[1].takeIf(::isSafeActiveResultCacheId) ?: return null
+    val colorMode = ScanColorMode.entries.firstOrNull { it.wireValue == fields[2] } ?: return null
+    val percentages = fields.drop(3).map { it.toIntOrNull()?.takeIf { value -> value in 0..100 } }
+    if (percentages.any { it == null }) return null
+    return ActiveResultCheckpoint(cacheId)
 }
 
 internal fun encodePendingShareCleanup(request: ShareCleanupRequest): String {
@@ -77,6 +129,9 @@ internal fun decodePendingShareCleanup(value: String?): ShareCleanupRequest? {
     return decodeShareCleanupRequest(parts[0], parts[1], parts[2])
         ?.takeIf { isSafeActiveResultCacheId(it.cacheId) }
 }
+
+internal fun decodeActiveResultCheckpoint(value: String?): String? =
+    decodeActiveResultCheckpointPayload(value)?.cacheId
 
 internal fun normalizeAlbumName(value: String): String {
     val trimmed = value.trim()
@@ -113,6 +168,7 @@ internal class SettingsStore(
 
     fun load(): AppSettings {
         val defaults = AppSettings(emailSubject = defaultEmailSubject)
+        val appearance = defaults.appearance
         return AppSettings(
             savePdf = readPreferenceOrDefault(defaults.savePdf) {
                 preferences.getBoolean(KEY_SAVE_PDF, defaults.savePdf)
@@ -152,10 +208,70 @@ internal class SettingsStore(
                     defaults.deleteImagesAfterShare,
                 )
             },
+            appearance =
+                parseScanAppearanceSettings(
+                    colorModeWireValue =
+                        readPreferenceOrDefault<String?>(null) {
+                            preferences.getString(KEY_APPEARANCE_MODE, null)
+                        },
+                    colorIntensity =
+                        readPreferenceOrDefault(appearance.colorIntensity) {
+                            preferences.getInt(
+                                KEY_APPEARANCE_COLOR_INTENSITY,
+                                appearance.colorIntensity,
+                            )
+                        },
+                    grayscaleIntensity =
+                        readPreferenceOrDefault(appearance.grayscaleIntensity) {
+                            preferences.getInt(
+                                KEY_APPEARANCE_GRAYSCALE_INTENSITY,
+                                appearance.grayscaleIntensity,
+                            )
+                        },
+                    blackWhiteIntensity =
+                        readPreferenceOrDefault(appearance.blackWhiteIntensity) {
+                            preferences.getInt(
+                                KEY_APPEARANCE_BLACK_WHITE_INTENSITY,
+                                appearance.blackWhiteIntensity,
+                            )
+                        },
+                    shadows =
+                        readPreferenceOrDefault(appearance.shadows) {
+                            preferences.getInt(KEY_APPEARANCE_SHADOWS, appearance.shadows)
+                        },
+                ),
+            pdfSizeTarget =
+                parsePdfSizeTarget(
+                    readPreferenceOrDefault<String?>(null) {
+                        preferences.getString(KEY_PDF_SIZE_TARGET, null)
+                    },
+                ),
         )
     }
 
     fun save(settings: AppSettings) {
+        saveLocked(settings)
+    }
+
+    @Throws(IOException::class)
+    internal fun trySave(
+        settings: AppSettings,
+        expectedOwner: ActiveResultOwner,
+    ): AuthorityMutationResult {
+        if (!ACTIVE_RESULT_AUTHORITY_LOCK.tryLock()) return AuthorityMutationResult.Busy
+        return try {
+            if (!ownerMatchesLocked(expectedOwner)) {
+                AuthorityMutationResult.Stale
+            } else {
+                saveLocked(settings)
+                AuthorityMutationResult.Applied
+            }
+        } finally {
+            ACTIVE_RESULT_AUTHORITY_LOCK.unlock()
+        }
+    }
+
+    private fun saveLocked(settings: AppSettings) {
         preferences
             .edit()
             .putBoolean(KEY_SAVE_PDF, settings.savePdf)
@@ -167,45 +283,185 @@ internal class SettingsStore(
             .putString(KEY_EMAIL_BODY, settings.emailBody)
             .putBoolean(KEY_DELETE_PDF_AFTER_SHARE, settings.deletePdfAfterShare)
             .putBoolean(KEY_DELETE_IMAGES_AFTER_SHARE, settings.deleteImagesAfterShare)
+            .putAppearance(settings.appearance)
+            .putString(KEY_PDF_SIZE_TARGET, settings.pdfSizeTarget.wireValue)
             .apply()
     }
 
+    internal fun saveEmailSubject(subject: String) {
+        preferences.edit().putString(KEY_EMAIL_SUBJECT, subject).apply()
+    }
+
     @Throws(IOException::class)
-    internal fun activeResultCacheId(): String? {
+    internal fun saveAppliedAppearanceAndActiveResult(
+        appearance: ScanAppearanceSettings,
+        pdfSizeTarget: PdfSizeTarget,
+        cacheId: String,
+        expectedOwner: ActiveResultOwner,
+    ): AppearanceCommitResult =
+        withActiveResultAuthority {
+            if (!ownerMatchesLocked(expectedOwner)) {
+                return@withActiveResultAuthority AppearanceCommitResult.Stale
+            }
+            val normalized = normalizeAppearanceSettings(appearance)
+            val target = ActiveResultCheckpoint(cacheId)
+            val checkpoint = encodeActiveResultCheckpoint(cacheId)
+            preferences
+                .edit()
+                .putAppearance(normalized)
+                .putString(KEY_PDF_SIZE_TARGET, pdfSizeTarget.wireValue)
+                .putString(KEY_ACTIVE_RESULT_CHECKPOINT, checkpoint)
+                .commit()
+            val storedCheckpoint = activeResultCheckpointLocked()
+            val loaded = load()
+            when {
+                storedCheckpoint == target &&
+                    loaded.appearance == normalized &&
+                    loaded.pdfSizeTarget == pdfSizeTarget -> AppearanceCommitResult.Applied
+                storedCheckpoint == expectedOwner.checkpoint -> AppearanceCommitResult.NotApplied
+                else -> throw IOException("Applied appearance checkpoint is ambiguous")
+            }
+        }
+
+    @Throws(IOException::class)
+    internal fun restoreAppearanceAuthority(
+        appearance: ScanAppearanceSettings,
+        pdfSizeTarget: PdfSizeTarget,
+        expectedOwner: ActiveResultOwner,
+    ): AuthorityMutationResult =
+        withActiveResultAuthority {
+            if (!ownerMatchesLocked(expectedOwner)) {
+                return@withActiveResultAuthority AuthorityMutationResult.Stale
+            }
+            val normalized = normalizeAppearanceSettings(appearance)
+            preferences
+                .edit()
+                .putAppearance(normalized)
+                .putString(KEY_PDF_SIZE_TARGET, pdfSizeTarget.wireValue)
+                .commit()
+            val loaded = load()
+            if (loaded.appearance != normalized || loaded.pdfSizeTarget != pdfSizeTarget) {
+                throw IOException("Appearance authority could not be restored")
+            }
+            AuthorityMutationResult.Applied
+        }
+
+    @Throws(IOException::class)
+    internal fun authoritySnapshot(): ActiveResultAuthoritySnapshot =
+        withActiveResultAuthority(::authoritySnapshotLocked)
+
+    @Throws(IOException::class)
+    internal fun <T> withAuthoritySnapshot(
+        block: (ActiveResultAuthoritySnapshot) -> T,
+    ): T = withActiveResultAuthority { block(authoritySnapshotLocked()) }
+
+    private fun authoritySnapshotLocked(): ActiveResultAuthoritySnapshot {
+        val checkpoint = activeResultCheckpointLocked()
+        check(activeResultAuthorityRevision < Long.MAX_VALUE) {
+            "Active result authority revision exhausted"
+        }
+        val owner = ActiveResultOwner(++activeResultAuthorityRevision, checkpoint)
+        return ActiveResultAuthoritySnapshot(
+            settings = load(),
+            checkpoint = checkpoint,
+            owner = owner,
+        )
+    }
+
+    @Throws(IOException::class)
+    internal fun activeResultCheckpoint(): ActiveResultCheckpoint? =
+        withActiveResultAuthority(::activeResultCheckpointLocked)
+
+    @Throws(IOException::class)
+    internal fun ownsActiveResult(owner: ActiveResultOwner): Boolean =
+        withActiveResultAuthority { ownerMatchesLocked(owner) }
+
+    private fun activeResultCheckpointLocked(): ActiveResultCheckpoint? {
         val storedValue =
             readPreferenceOrDefault<String?>(null) {
                 preferences.getString(KEY_ACTIVE_RESULT_CHECKPOINT, null)
             }
-        val cacheId = decodeActiveResultCheckpoint(storedValue)
-        if (cacheId == null && preferences.contains(KEY_ACTIVE_RESULT_CHECKPOINT)) {
-            clearActiveResult()
+        val checkpoint = decodeActiveResultCheckpointPayload(storedValue)
+        if (checkpoint == null && preferences.contains(KEY_ACTIVE_RESULT_CHECKPOINT)) {
+            throw IOException("Active result checkpoint is invalid")
         }
-        return cacheId
+        return checkpoint
     }
 
+    private fun ownerMatchesLocked(owner: ActiveResultOwner): Boolean =
+        owner.revision == activeResultAuthorityRevision &&
+            owner.checkpoint == activeResultCheckpointLocked()
+
     @Throws(IOException::class)
-    internal fun saveActiveResult(cacheId: String) {
-        val checkpoint = encodeActiveResultCheckpoint(cacheId)
-        val stored =
-            preferences.edit().putString(KEY_ACTIVE_RESULT_CHECKPOINT, checkpoint).commit()
-        val verified =
+    internal fun activeResultCacheId(): String? = activeResultCheckpoint()?.cacheId
+
+    @Throws(IOException::class)
+    internal fun saveActiveResult(
+        cacheId: String,
+        expectedOwner: ActiveResultOwner,
+    ): AuthorityMutationResult =
+        withActiveResultAuthority {
+            if (!ownerMatchesLocked(expectedOwner)) {
+                return@withActiveResultAuthority AuthorityMutationResult.Stale
+            }
+            val encoded = encodeActiveResultCheckpoint(cacheId)
+            preferences.edit().putString(KEY_ACTIVE_RESULT_CHECKPOINT, encoded).commit()
+            val verified =
+                readPreferenceOrDefault<String?>(null) {
+                    preferences.getString(KEY_ACTIVE_RESULT_CHECKPOINT, null)
+                } == encoded
+            if (!verified) {
+                throw IOException("Active result could not be stored")
+            }
+            AuthorityMutationResult.Applied
+        }
+
+    @Throws(IOException::class)
+    internal fun clearActiveResult(
+        expectedOwner: ActiveResultOwner,
+    ): AuthorityMutationResult =
+        withActiveResultAuthority {
+            if (!ownerMatchesLocked(expectedOwner)) {
+                return@withActiveResultAuthority AuthorityMutationResult.Stale
+            }
+            if (expectedOwner.checkpoint == null) {
+                return@withActiveResultAuthority AuthorityMutationResult.Applied
+            }
+            preferences.edit().remove(KEY_ACTIVE_RESULT_CHECKPOINT).commit()
+            if (activeResultCheckpointLocked() != null) {
+                throw IOException("Active result could not be cleared")
+            }
+            AuthorityMutationResult.Applied
+        }
+
+    internal fun pendingPdfTreeUri(): String? =
+        withStorageTransaction {
             readPreferenceOrDefault<String?>(null) {
-                preferences.getString(KEY_ACTIVE_RESULT_CHECKPOINT, null)
-            } == checkpoint
-        if (!stored || !verified) {
-            throw IOException("Active result could not be stored")
+                preferences.getString(KEY_PENDING_PDF_TREE_URI, null)
+            }
         }
-    }
 
     @Throws(IOException::class)
-    internal fun clearActiveResult() {
-        if (!preferences.contains(KEY_ACTIVE_RESULT_CHECKPOINT)) return
-        val cleared = preferences.edit().remove(KEY_ACTIVE_RESULT_CHECKPOINT).commit()
-        if (!cleared || preferences.contains(KEY_ACTIVE_RESULT_CHECKPOINT)) {
-            throw IOException("Active result could not be cleared")
+    internal fun savePdfTreeUris(current: String?, pending: String?) =
+        withStorageTransaction {
+            val stored =
+                preferences
+                    .edit()
+                    .putString(KEY_PDF_TREE_URI, current)
+                    .putString(KEY_PENDING_PDF_TREE_URI, pending)
+                    .commit()
+            val currentRead =
+                readPreferenceOrDefault<String?>(null) {
+                    preferences.getString(KEY_PDF_TREE_URI, null)
+                }
+            val pendingRead =
+                readPreferenceOrDefault<String?>(null) {
+                    preferences.getString(KEY_PENDING_PDF_TREE_URI, null)
+                }
+            if (!stored || currentRead != current || pendingRead != pending) {
+                throw IOException("PDF destinations could not be stored")
+            }
         }
-    }
-
     @Throws(IOException::class)
     internal fun pendingShareCleanups(): List<ShareCleanupRequest> =
         shareCleanupQueueLock.withLock {
@@ -276,27 +532,33 @@ internal class SettingsStore(
         if (!stored || !verified) throw IOException("Pending share cleanup could not be stored")
     }
 
-    internal fun pendingPdfTreeUri(): String? =
-        readPreferenceOrDefault<String?>(null) {
-            preferences.getString(KEY_PENDING_PDF_TREE_URI, null)
-        }
-
     internal fun currentPdfTreeUri(): String? =
-        readPreferenceOrDefault<String?>(null) {
-            preferences.getString(KEY_PDF_TREE_URI, null)
+        withStorageTransaction {
+            readPreferenceOrDefault<String?>(null) {
+                preferences.getString(KEY_PDF_TREE_URI, null)
+            }
         }
-
-    @Throws(IOException::class)
-    internal fun savePdfTreeUris(current: String?, pending: String?) {
-        val stored =
-            preferences
-                .edit()
-                .putString(KEY_PDF_TREE_URI, current)
-                .putString(KEY_PENDING_PDF_TREE_URI, pending)
-                .commit()
-        if (!stored) {
-            throw IOException("PDF destinations could not be stored")
-        }
-    }
 
 }
+
+private fun SharedPreferences.Editor.putAppearance(
+    appearance: ScanAppearanceSettings,
+): SharedPreferences.Editor {
+    val normalized = normalizeAppearanceSettings(appearance)
+    return putString(KEY_APPEARANCE_MODE, normalized.colorMode.wireValue)
+        .putInt(KEY_APPEARANCE_COLOR_INTENSITY, normalized.colorIntensity)
+        .putInt(KEY_APPEARANCE_GRAYSCALE_INTENSITY, normalized.grayscaleIntensity)
+        .putInt(KEY_APPEARANCE_BLACK_WHITE_INTENSITY, normalized.blackWhiteIntensity)
+        .putInt(KEY_APPEARANCE_SHADOWS, normalized.shadows)
+}
+
+private fun normalizeAppearanceSettings(
+    appearance: ScanAppearanceSettings,
+): ScanAppearanceSettings =
+    parseScanAppearanceSettings(
+        colorModeWireValue = appearance.colorMode.wireValue,
+        colorIntensity = appearance.colorIntensity,
+        grayscaleIntensity = appearance.grayscaleIntensity,
+        blackWhiteIntensity = appearance.blackWhiteIntensity,
+        shadows = appearance.shadows,
+    )

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -66,6 +66,7 @@
     <string name="saving">Ukládání</string>
     <string name="save_pdf">Automaticky ukládat PDF</string>
     <string name="save_images">Ukládat obrázky do Galerie</string>
+    <string name="automatic_saving_scope">Automatické ukládání platí pro nové skeny. Úpravy vzhledu uložte v detailech souboru.</string>
     <string name="album_name">Název alba v Galerii</string>
     <string name="default_pdf_folder">PDF: Výchozí složka Stažené/Scan to PDF</string>
     <string name="custom_pdf_folder">PDF: Vlastní složka je vybraná</string>
@@ -88,6 +89,23 @@
     <string name="privacy_policy">Zásady ochrany osobních údajů</string>
     <string name="third_party_notices">Oznámení třetích stran</string>
     <string name="settings_save_failed">Nastavení se nepodařilo uložit.</string>
+    <string name="appearance">Vzhled</string>
+    <string name="default_appearance">Výchozí vzhled skenu</string>
+    <string name="filter_color">Barva</string>
+    <string name="filter_grayscale">Odstíny šedi</string>
+    <string name="filter_black_white">Černobíle</string>
+    <string name="filter_intensity_percent">Intenzita filtru: %1$d%%</string>
+    <string name="shadows_percent">Stíny: %1$d%%</string>
+    <string name="edit_appearance">Upravit vzhled</string>
+    <string name="apply_appearance">Použít</string>
+    <string name="applying_appearance">Používám…</string>
+    <string name="appearance_apply_failed">Vzhled se nepodařilo použít. Předchozí sken zůstal zachovaný.</string>
+    <string name="pdf_size">Velikost PDF</string>
+    <string name="pdf_size_original">Původní</string>
+    <string name="pdf_size_5_mb">5 MB</string>
+    <string name="pdf_size_10_mb">10 MB</string>
+    <string name="pdf_size_20_mb">20 MB</string>
+    <string name="pdf_size_hint">Limit se vyhodnocuje podle skutečně vytvořených čitelných verzí. Pokud jej nelze dodržet, ScanIt ponechá nejmenší čitelné PDF a zobrazí jeho skutečnou velikost.</string>
 
     <string name="language">Jazyk</string>
     <string name="language_system">Podle systému</string>
@@ -104,6 +122,7 @@
     <string name="saving_document">Dokument se ukládá…</string>
     <string name="images_save_failed">Obrázky se nepodařilo uložit do Galerie. Dokument lze stále odeslat.</string>
     <string name="pdf_save_failed">PDF se nepodařilo uložit. Dokument lze stále odeslat.</string>
+    <string name="pdf_size_target_not_met">PDF se nepodařilo zmenšit pod %1$d MB bez příliš malých stránek. Skutečná velikost: %2$.2f MB.</string>
     <string name="document_save_failed">Dokument se nepodařilo uložit. Zkuste to znovu.</string>
     <string name="document_save_partial_failed">Dokument se nepodařilo uložit. Některé soubory mohly zůstat uložené.</string>
     <string name="saf_fallback_warning">Vybraná složka není dostupná. PDF bylo uloženo do Stažených souborů.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="saving">Saving</string>
     <string name="save_pdf">Save PDF automatically</string>
     <string name="save_images">Save images to Gallery</string>
+    <string name="automatic_saving_scope">Automatic saving applies to new scans. Save appearance edits from File details.</string>
     <string name="album_name">Gallery album name</string>
     <string name="default_pdf_folder">PDF: Default Downloads/Scan to PDF folder</string>
     <string name="custom_pdf_folder">PDF: Custom folder selected</string>
@@ -86,6 +87,23 @@
     <string name="privacy_policy">Privacy policy</string>
     <string name="third_party_notices">Third-party notices</string>
     <string name="settings_save_failed">Could not save settings.</string>
+    <string name="appearance">Appearance</string>
+    <string name="default_appearance">Default scan appearance</string>
+    <string name="filter_color">Color</string>
+    <string name="filter_grayscale">Grayscale</string>
+    <string name="filter_black_white">B&amp;W</string>
+    <string name="filter_intensity_percent">Filter intensity: %1$d%%</string>
+    <string name="shadows_percent">Shadows: %1$d%%</string>
+    <string name="edit_appearance">Edit appearance</string>
+    <string name="apply_appearance">Apply</string>
+    <string name="applying_appearance">Applying…</string>
+    <string name="appearance_apply_failed">Could not apply the appearance. The previous scan was kept.</string>
+    <string name="pdf_size">PDF size</string>
+    <string name="pdf_size_original">Original</string>
+    <string name="pdf_size_5_mb">5 MB</string>
+    <string name="pdf_size_10_mb">10 MB</string>
+    <string name="pdf_size_20_mb">20 MB</string>
+    <string name="pdf_size_hint">Size limits use measured, readable versions. If a limit cannot be reached, ScanIt keeps the smallest readable PDF and shows its actual size.</string>
 
     <string name="language">Language</string>
     <string name="language_system">System default</string>
@@ -102,6 +120,7 @@
     <string name="saving_document">Saving document…</string>
     <string name="images_save_failed">Images could not be saved to Gallery. The document can still be shared.</string>
     <string name="pdf_save_failed">The PDF could not be saved. The document can still be shared.</string>
+    <string name="pdf_size_target_not_met">The PDF could not fit under %1$d MB without making pages too small. Actual size: %2$.2f MB.</string>
     <string name="document_save_failed">Could not save the document. Try again.</string>
     <string name="document_save_partial_failed">Could not save the document. Some files may remain saved.</string>
     <string name="saf_fallback_warning">The selected folder is unavailable. The PDF was saved to Downloads.</string>

--- a/app/src/test/java/com/majkeylab/scanit/BitonalPdfWriterTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/BitonalPdfWriterTest.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
+import java.util.concurrent.CancellationException
 import java.util.zip.InflaterInputStream
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -91,7 +92,10 @@ class BitonalPdfWriterTest {
             assertTrue(text.contains("/Length 7 0 R"))
             assertEquals(streamLength(pdf, 4, 5), objectNumber(text, 5))
             assertEquals(streamLength(pdf, 6, 7), objectNumber(text, 7))
-            assertEquals("q\n8 0 0 2 0 0 cm\n/Im0 Do\nQ\n", stream(pdf, 6, 7).decodeToString())
+            assertEquals(
+                "q\n1.92 0 0 0.48 0 0 cm\n/Im0 Do\nQ\n",
+                stream(pdf, 6, 7).decodeToString(),
+            )
         }
 
     @Test
@@ -114,10 +118,33 @@ class BitonalPdfWriterTest {
             val pdf = output.readBytes()
             val text = pdf.toString(StandardCharsets.ISO_8859_1)
             assertTrue(text.contains("/Kids [3 0 R 8 0 R] /Count 2"))
-            assertTrue(text.contains("/MediaBox [0 0 8 2]"))
-            assertTrue(text.contains("/MediaBox [0 0 3 1]"))
+            assertTrue(text.contains("/MediaBox [0 0 1.92 0.48]"))
+            assertTrue(text.contains("/MediaBox [0 0 0.72 0.24]"))
             assertArrayEquals(byteArrayOf(0x00, 0xff.toByte()), inflatedImage(pdf, 4, 5))
             assertArrayEquals(byteArrayOf(0xff.toByte()), inflatedImage(pdf, 9, 10))
+        }
+
+    @Test
+    fun downsampledBitonalImageKeepsOriginalPhysicalPageSize() =
+        withTempDirectory { directory ->
+            val output = File(directory, "physical.pdf")
+
+            BitonalPdfWriter.write(
+                output,
+                listOf(
+                    BitonalPdfPage(
+                        width = 4,
+                        height = 1,
+                        physicalWidthPixels = 8,
+                        physicalHeightPixels = 2,
+                    ) { _, pixels -> pixels.fill(WHITE) },
+                ),
+            )
+
+            val text = output.readText(StandardCharsets.ISO_8859_1)
+            assertTrue(text.contains("/Width 4 /Height 1"))
+            assertTrue(text.contains("/MediaBox [0 0 1.92 0.48]"))
+            assertTrue(text.contains("q\n1.92 0 0 0.48 0 0 cm\n/Im0 Do\nQ\n"))
         }
 
     @Test
@@ -175,6 +202,71 @@ class BitonalPdfWriterTest {
         }
 
     @Test
+    fun pageCompletionRunsAfterSuccessfulAndFailedRows() =
+        withTempDirectory { directory ->
+            var completed = 0
+            BitonalPdfWriter.write(
+                File(directory, "success.pdf"),
+                listOf(
+                    BitonalPdfPage(
+                        width = 1,
+                        height = 1,
+                        readRow = { _, pixels -> pixels[0] = WHITE },
+                        onComplete = { completed++ },
+                    ),
+                ),
+            )
+            try {
+                BitonalPdfWriter.write(
+                    File(directory, "failure.pdf"),
+                    listOf(
+                        BitonalPdfPage(
+                            width = 1,
+                            height = 1,
+                            readRow = { _, _ -> throw IOException("failure") },
+                            onComplete = { completed++ },
+                        ),
+                    ),
+                )
+                fail("Expected row failure")
+            } catch (_: IOException) {}
+
+            assertEquals(2, completed)
+        }
+
+    @Test
+    fun cancellationDuringRowsCleansStagingAndCompletesActivePageOnce() =
+        withTempDirectory { directory ->
+            val output = File(directory, "cancelled.pdf")
+            var rowsRead = 0
+            var completed = 0
+
+            try {
+                BitonalPdfWriter.write(
+                    output,
+                    listOf(
+                        BitonalPdfPage(
+                            width = 8,
+                            height = 3,
+                            readRow = { _, pixels ->
+                                rowsRead++
+                                pixels.fill(WHITE)
+                            },
+                            onComplete = { completed++ },
+                        ),
+                    ),
+                    isCancelled = { rowsRead >= 1 },
+                )
+                fail("Expected cancellation")
+            } catch (_: CancellationException) {}
+
+            assertEquals(1, rowsRead)
+            assertEquals(1, completed)
+            assertFalse(output.exists())
+            assertTrue(directory.listFiles()?.isEmpty() == true)
+        }
+
+    @Test
     fun destinationCreatedWhileWritingIsNotOverwritten() =
         withTempDirectory { directory ->
             val output = File(directory, "raced.pdf")
@@ -200,8 +292,8 @@ class BitonalPdfWriterTest {
     @Test
     fun oversizedWidthIsRejectedBeforeCreatingFiles() {
         assertWriteRejected(
-            listOf(BitonalPdfPage(width = 3509, height = 1) { _, _ -> fail("Row read") }),
-            "Page width exceeds 3508 pixels",
+            listOf(BitonalPdfPage(width = 6001, height = 1) { _, _ -> fail("Row read") }),
+            "Page width exceeds 6000 pixels",
         )
     }
 
@@ -224,16 +316,16 @@ class BitonalPdfWriterTest {
     @Test
     fun oversizedHeightIsRejectedBeforeCreatingFiles() {
         assertWriteRejected(
-            listOf(BitonalPdfPage(width = 1, height = 3509) { _, _ -> fail("Row read") }),
-            "Page height exceeds 3508 pixels",
+            listOf(BitonalPdfPage(width = 1, height = 6001) { _, _ -> fail("Row read") }),
+            "Page height exceeds 6000 pixels",
         )
     }
 
     @Test
     fun oversizedPixelProductIsRejectedBeforeCreatingFiles() {
         assertWriteRejected(
-            listOf(BitonalPdfPage(width = 3509, height = 3509) { _, _ -> fail("Row read") }),
-            "Page pixel count exceeds 12306064",
+            listOf(BitonalPdfPage(width = 4000, height = 4000) { _, _ -> fail("Row read") }),
+            "Page pixel count exceeds 12000000",
         )
     }
 
@@ -241,14 +333,14 @@ class BitonalPdfWriterTest {
     fun oversizedPageCountIsRejectedBeforeCreatingFiles() {
         val page = BitonalPdfPage(width = 1, height = 1) { _, _ -> fail("Row read") }
         assertWriteRejected(
-            List(26_214) { page },
-            "PDF page count exceeds 26213",
+            List(MAX_SCAN_PAGES + 1) { page },
+            "PDF page count exceeds $MAX_SCAN_PAGES",
         )
     }
 
     @Test
-    fun maximumSafePageCountKeepsObjectTableWithinBudget() {
-        assertEquals(131_067, bitonalPdfObjectCount(26_213))
+    fun maximumScanPageCountKeepsObjectTableBounded() {
+        assertEquals(102, bitonalPdfObjectCount(MAX_SCAN_PAGES))
     }
 
     @Test

--- a/app/src/test/java/com/majkeylab/scanit/JpegPdfWriterTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/JpegPdfWriterTest.kt
@@ -1,0 +1,170 @@
+package com.majkeylab.scanit
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.util.concurrent.CancellationException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JpegPdfWriterTest {
+    @Test
+    fun writesJpegBytesIntoAParseableDctImageObject() {
+        val root = Files.createTempDirectory("scanit-jpeg-pdf").toFile()
+        try {
+            val jpeg = File(root, "page.jpg").apply { writeBytes(JPEG_BYTES) }
+            val pdf = File(root, "scan.pdf")
+
+            JpegPdfWriter.write(pdf, listOf(JpegPdfPage(jpeg, width = 32, height = 48)))
+
+            val bytes = pdf.readBytes()
+            val text = bytes.toString(Charsets.ISO_8859_1)
+            assertTrue(text.startsWith("%PDF-1.4\n"))
+            assertTrue(text.contains("/Width 32 /Height 48"))
+            assertTrue(text.contains("/MediaBox [0 0 7.68 11.52]"))
+            assertTrue(text.contains("q\n7.68 0 0 11.52 0 0 cm\n/Im0 Do\nQ\n"))
+            assertTrue(text.contains("/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode"))
+            assertTrue(text.contains("\n${JPEG_BYTES.size}\nendobj\n"))
+            assertArrayEquals(JPEG_BYTES, bytes.copyOfRange(bytes.indexOfSequence(JPEG_BYTES), bytes.indexOfSequence(JPEG_BYTES) + JPEG_BYTES.size))
+            val startXref = text.substringAfterLast("startxref\n").substringBefore('\n').toInt()
+            assertTrue(text.substring(startXref).startsWith("xref\n"))
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    @Test
+    fun downsampledImageKeepsOriginalPhysicalPageSize() {
+        val root = Files.createTempDirectory("scanit-jpeg-pdf-physical").toFile()
+        try {
+            val jpeg = File(root, "page.jpg").apply { writeBytes(JPEG_BYTES) }
+            val pdf = File(root, "scan.pdf")
+
+            JpegPdfWriter.write(
+                pdf,
+                listOf(
+                    JpegPdfPage(
+                        jpeg,
+                        width = 16,
+                        height = 24,
+                        physicalWidthPixels = 32,
+                        physicalHeightPixels = 48,
+                    ),
+                ),
+            )
+
+            val text = pdf.readText(Charsets.ISO_8859_1)
+            assertTrue(text.contains("/Width 16 /Height 24"))
+            assertTrue(text.contains("/MediaBox [0 0 7.68 11.52]"))
+            assertTrue(text.contains("q\n7.68 0 0 11.52 0 0 cm\n/Im0 Do\nQ\n"))
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    @Test
+    fun preservesExistingDestinationAndCleansStagingFile() {
+        val root = Files.createTempDirectory("scanit-jpeg-pdf-existing").toFile()
+        try {
+            val jpeg = File(root, "page.jpg").apply { writeBytes(JPEG_BYTES) }
+            val pdf = File(root, "scan.pdf").apply { writeText("sentinel") }
+
+            assertThrows(Exception::class.java) {
+                JpegPdfWriter.write(pdf, listOf(JpegPdfPage(jpeg, width = 1, height = 1)))
+            }
+
+            assertEquals("sentinel", pdf.readText())
+            assertEquals(emptyList<String>(), root.listFiles()!!.map(File::getName).filter { it.startsWith(".scanit-pdf-") })
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    @Test
+    fun publicationRollsBackTargetWhenStagingCleanupFails() {
+        val root = Files.createTempDirectory("scanit-pdf-publication").toFile()
+        try {
+            val staging = File(root, "staging.part").apply { writeText("complete") }
+            val target = File(root, "scan.pdf")
+
+            val failure =
+                assertThrows(IOException::class.java) {
+                    publishStagedFileNoReplace(
+                        staging.toPath(),
+                        target.toPath(),
+                        deleteIfExists = { path ->
+                            if (path == staging.toPath()) throw IOException("cleanup failed")
+                            Files.deleteIfExists(path)
+                        },
+                    )
+                }
+
+            assertEquals("cleanup failed", failure.message)
+            assertFalse(target.exists())
+            assertTrue(staging.isFile)
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    @Test
+    fun cancellationDuringJpegCopyDoesNotPublishOrLeaveStaging() {
+        val root = Files.createTempDirectory("scanit-jpeg-pdf-cancel").toFile()
+        try {
+            val jpeg = File(root, "page.jpg").apply { writeBytes(ByteArray(32_000) { 0x41 }) }
+            val pdf = File(root, "scan.pdf")
+            var checks = 0
+
+            assertThrows(CancellationException::class.java) {
+                JpegPdfWriter.write(
+                    pdf,
+                    listOf(JpegPdfPage(jpeg, width = 100, height = 100)),
+                    isCancelled = { ++checks >= 5 },
+                )
+            }
+
+            assertTrue(checks >= 5)
+            assertFalse(pdf.exists())
+            assertTrue(root.listFiles()!!.none { it.name.startsWith(".scanit-pdf-") })
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    @Test
+    fun rejectsMissingEmptyAndInvalidPagesBeforeCreatingOutput() {
+        val root = Files.createTempDirectory("scanit-jpeg-pdf-invalid").toFile()
+        try {
+            val empty = File(root, "empty.jpg").apply { createNewFile() }
+            val output = File(root, "scan.pdf")
+
+            assertThrows(IllegalArgumentException::class.java) {
+                JpegPdfWriter.write(output, emptyList())
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                JpegPdfWriter.write(output, listOf(JpegPdfPage(empty, width = 1, height = 1)))
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                JpegPdfWriter.write(output, listOf(JpegPdfPage(File(root, "missing.jpg"), 1, 1)))
+            }
+            assertTrue(!output.exists())
+        } finally {
+            assertTrue(root.deleteRecursively())
+        }
+    }
+
+    private fun ByteArray.indexOfSequence(sequence: ByteArray): Int {
+        for (index in 0..size - sequence.size) {
+            if (sequence.indices.all { this[index + it] == sequence[it] }) return index
+        }
+        throw AssertionError("Embedded JPEG was not found")
+    }
+
+    private companion object {
+        val JPEG_BYTES = byteArrayOf(0xff.toByte(), 0xd8.toByte(), 1, 2, 3, 0xff.toByte(), 0xd9.toByte())
+    }
+}

--- a/app/src/test/java/com/majkeylab/scanit/OutputSavePolicyTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/OutputSavePolicyTest.kt
@@ -1,0 +1,37 @@
+package com.majkeylab.scanit
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OutputSavePolicyTest {
+    @Test
+    fun automaticOutputTargetMatchesSavedOutputSettings() {
+        assertEquals(
+            SaveNowTarget.Both,
+            automaticOutputTarget(AppSettings(savePdf = true, saveImages = true)),
+        )
+        assertEquals(
+            SaveNowTarget.Pdf,
+            automaticOutputTarget(AppSettings(savePdf = true, saveImages = false)),
+        )
+        assertEquals(
+            SaveNowTarget.Images,
+            automaticOutputTarget(AppSettings(savePdf = false, saveImages = true)),
+        )
+        assertNull(automaticOutputTarget(AppSettings(savePdf = false, saveImages = false)))
+    }
+
+    @Test
+    fun persistedPdfTargetWarningUsesExactDecimalLimit() {
+        assertNull(pdfSizeTargetWarning(PdfSizeTarget.Original, 99_000_000L))
+        assertNull(pdfSizeTargetWarning(PdfSizeTarget.Mb5, 5_000_000L))
+        assertEquals(
+            UiMessage(
+                R.string.pdf_size_target_not_met,
+                listOf(5, 5.000001),
+            ),
+            pdfSizeTargetWarning(PdfSizeTarget.Mb5, 5_000_001L),
+        )
+    }
+}

--- a/app/src/test/java/com/majkeylab/scanit/PdfSizePolicyTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PdfSizePolicyTest.kt
@@ -1,0 +1,92 @@
+package com.majkeylab.scanit
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PdfSizePolicyTest {
+    @Test
+    fun namedPdfLimitsUseDecimalMegabytes() {
+        assertEquals(5_000_000L, PdfSizeTarget.Mb5.maxBytes)
+        assertEquals(10_000_000L, PdfSizeTarget.Mb10.maxBytes)
+        assertEquals(20_000_000L, PdfSizeTarget.Mb20.maxBytes)
+    }
+
+    @Test
+    fun eachFilterKeepsItsOwnIntensityAndSuccessfulModeBecomesCurrent() {
+        val settings =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.BlackWhite,
+                colorIntensity = 20,
+                grayscaleIntensity = 40,
+                blackWhiteIntensity = 100,
+                shadows = 50,
+            )
+
+        val applied =
+            settings.withApplied(
+                ScanAppearance(
+                    colorMode = ScanColorMode.Grayscale,
+                    intensity = 65,
+                    shadows = 35,
+                ),
+            )
+
+        assertEquals(20, applied.colorIntensity)
+        assertEquals(65, applied.grayscaleIntensity)
+        assertEquals(100, applied.blackWhiteIntensity)
+        assertEquals(ScanAppearance(ScanColorMode.Grayscale, 65, 35), applied.selected())
+    }
+
+    @Test
+    fun cleanInstallAppearanceIsBlackWhiteFullStrengthWithHalfShadows() {
+        assertEquals(
+            ScanAppearance(ScanColorMode.BlackWhite, intensity = 100, shadows = 50),
+            ScanAppearanceSettings().selected(),
+        )
+    }
+
+    @Test
+    fun resolutionProfilesNeverDropAnyPageBelowLegibleEdge() {
+        assertEquals(listOf(1, 2), pdfSampleMultipliers(listOf(3_508, 3_508)))
+        assertEquals(listOf(1, 2, 4), pdfSampleMultipliers(listOf(6_000, 5_200)))
+        assertEquals(listOf(1, 2), pdfSampleMultipliers(listOf(1_000, 4_000)))
+        assertEquals(listOf(1), pdfSampleMultipliers(listOf(2_559)))
+        assertEquals(1, legiblePdfSampleMultiplier(longestEdge = 2_559, requestedMultiplier = 2))
+    }
+
+    @Test
+    fun pdfPolicyRejectsInvalidMeasurements() {
+        assertThrows(IllegalArgumentException::class.java) {
+            pdfSampleMultipliers(listOf(0))
+        }
+    }
+
+    @Test
+    fun bitonalEncodingWinsOnlyWhenEligibleAndStrictlySmaller() {
+        assertEquals(PdfEncoding.Bitonal, selectPdfEncoding(1_000, 600, bitonalEligible = true))
+        assertEquals(PdfEncoding.Jpeg, selectPdfEncoding(1_000, 1_000, bitonalEligible = true))
+        assertEquals(PdfEncoding.Jpeg, selectPdfEncoding(1_000, 600, bitonalEligible = false))
+    }
+
+    @Test
+    fun bitonalCandidateRequiresFullStrengthBlackWhiteAppearance() {
+        assertTrue(isBitonalPdfEligible(ScanAppearance(ScanColorMode.BlackWhite, 100, 50)))
+        assertFalse(isBitonalPdfEligible(ScanAppearance(ScanColorMode.BlackWhite, 99, 50)))
+        assertFalse(isBitonalPdfEligible(ScanAppearance(ScanColorMode.Grayscale, 100, 50)))
+    }
+
+    @Test
+    fun relativePdfSamplingKeepsRendererBaseBound() {
+        assertEquals(1, relativePdfSourceSampleSize(1, 1))
+        assertEquals(8, relativePdfSourceSampleSize(2, 4))
+        assertThrows(IllegalArgumentException::class.java) {
+            relativePdfSourceSampleSize(3, 2)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            relativePdfSourceSampleSize(1 shl 30, 4)
+        }
+    }
+}

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -8,6 +8,10 @@ import java.nio.file.Files
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 import kotlinx.coroutines.CancellationException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,6 +36,8 @@ class PureLogicTest {
                 pdfTreeUri = null,
                 deletePdfAfterShare = false,
                 deleteImagesAfterShare = false,
+                appearance = ScanAppearanceSettings(),
+                pdfSizeTarget = PdfSizeTarget.Original,
             ),
             AppSettings(),
         )
@@ -101,8 +107,12 @@ class PureLogicTest {
         val store = SettingsStore(preferences, "Scanned document")
         val enabled =
             AppSettings(deletePdfAfterShare = true, deleteImagesAfterShare = true)
+        val owner = store.authoritySnapshot().owner
 
-        store.save(enabled)
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.trySave(enabled, owner),
+        )
 
         assertTrue(store.load().deletePdfAfterShare)
         assertTrue(store.load().deleteImagesAfterShare)
@@ -238,6 +248,509 @@ class PureLogicTest {
         second.savePdfTreeUris(current = "content://docs/tree/current", pending = null)
         first.save(AppSettings(pdfTreeUri = "content://docs/tree/current"))
         assertNull(first.pendingPdfTreeUri())
+    }
+
+    @Test
+    fun appearanceAndPdfSizeSettingsRoundTripWithStableValues() {
+        val (preferences, values) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val expected =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Grayscale,
+                colorIntensity = 15,
+                grayscaleIntensity = 35,
+                blackWhiteIntensity = 75,
+                shadows = 45,
+            )
+        val owner = store.authoritySnapshot().owner
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.trySave(
+                AppSettings(
+                    appearance = expected,
+                    pdfSizeTarget = PdfSizeTarget.Mb10,
+                ),
+                expectedOwner = owner,
+            ),
+        )
+
+        assertEquals(expected, store.load().appearance)
+        assertEquals(PdfSizeTarget.Mb10, store.load().pdfSizeTarget)
+        assertEquals("grayscale", values["appearance_mode"])
+        assertEquals("10_mb", values["pdf_size_target"])
+    }
+
+    @Test
+    fun corruptAppearanceAndPdfSizeSettingsFailClosedToDefaults() {
+        val (preferences, values) = inMemoryPreferences()
+        values["appearance_mode"] = "future"
+        values["appearance_color_intensity"] = -10
+        values["appearance_grayscale_intensity"] = 140
+        values["appearance_black_white_intensity"] = "wrong"
+        values["appearance_shadows"] = 101
+        values["pdf_size_target"] = "1_mb"
+
+        val loaded = SettingsStore(preferences, "Scanned document").load()
+
+        assertEquals(ScanColorMode.BlackWhite, loaded.appearance.colorMode)
+        assertEquals(0, loaded.appearance.colorIntensity)
+        assertEquals(100, loaded.appearance.grayscaleIntensity)
+        assertEquals(100, loaded.appearance.blackWhiteIntensity)
+        assertEquals(100, loaded.appearance.shadows)
+        assertEquals(PdfSizeTarget.Original, loaded.pdfSizeTarget)
+    }
+
+    @Test
+    fun successfulResultApplyDurablyStoresAppearanceAndNewCheckpointTogether() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val owner = store.authoritySnapshot().owner
+        val appearance =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Color,
+                colorIntensity = 42,
+                grayscaleIntensity = 61,
+                blackWhiteIntensity = 100,
+                shadows = 27,
+            )
+
+        val result =
+            store.saveAppliedAppearanceAndActiveResult(
+                appearance,
+                PdfSizeTarget.Mb5,
+                "Scan_applied",
+                owner,
+            )
+
+        assertEquals(AppearanceCommitResult.Applied, result)
+        assertEquals(appearance, store.load().appearance)
+        assertEquals(PdfSizeTarget.Mb5, store.load().pdfSizeTarget)
+        assertEquals("Scan_applied", store.activeResultCacheId())
+        assertEquals(
+            ActiveResultCheckpoint("Scan_applied"),
+            store.activeResultCheckpoint(),
+        )
+    }
+
+    @Test
+    fun failedCommitWithCandidateReadbackKeepsMonotonicAuthority() {
+        val (preferences, _) = inMemoryPreferences(commitResults = listOf(false))
+        val store = SettingsStore(preferences, "Scanned document")
+        val owner = store.authoritySnapshot().owner
+        val appearance =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Color,
+                colorIntensity = 35,
+                shadows = 20,
+            )
+
+        val result =
+            store.saveAppliedAppearanceAndActiveResult(
+                appearance,
+                PdfSizeTarget.Mb10,
+                "Scan_applied",
+                expectedOwner = owner,
+            )
+
+        assertEquals(AppearanceCommitResult.Applied, result)
+        assertEquals(appearance, store.load().appearance)
+        assertEquals(PdfSizeTarget.Mb10, store.load().pdfSizeTarget)
+        assertEquals(ActiveResultCheckpoint("Scan_applied"), store.activeResultCheckpoint())
+    }
+
+    @Test
+    fun appearanceCommitRejectsCheckpointWhenAppearanceReadbackDoesNotMatch() {
+        val (preferences, _) =
+            inMemoryPreferences(
+                commitResults = listOf(false),
+                afterCommit = { _, values -> values.remove("appearance_mode") },
+            )
+        val store = SettingsStore(preferences, "Scanned document")
+        val owner = store.authoritySnapshot().owner
+
+        assertThrows(IOException::class.java) {
+            store.saveAppliedAppearanceAndActiveResult(
+                ScanAppearanceSettings(colorMode = ScanColorMode.Color),
+                PdfSizeTarget.Mb5,
+                "Scan_applied",
+                owner,
+            )
+        }
+    }
+
+    @Test
+    fun falseCommitReturnStillSucceedsWhenEveryExactReadbackMatches() {
+        val (preferences, _) = inMemoryPreferences(commitResults = listOf(false, false, false))
+        val store = SettingsStore(preferences, "Scanned document")
+        val initialOwner = store.authoritySnapshot().owner
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_candidate", initialOwner),
+        )
+        val candidateOwner =
+            initialOwner.withCheckpoint(ActiveResultCheckpoint("Scan_candidate"))
+        val appearance = ScanAppearanceSettings(colorMode = ScanColorMode.Grayscale)
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.restoreAppearanceAuthority(appearance, PdfSizeTarget.Mb5, candidateOwner),
+        )
+        assertEquals(appearance, store.load().appearance)
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.clearActiveResult(candidateOwner),
+        )
+        assertNull(store.activeResultCheckpoint())
+    }
+
+    @Test
+    fun staleActiveResultOwnerCannotOverwriteOrClearANewerCheckpoint() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val originalOwner = store.authoritySnapshot().owner
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_first", originalOwner),
+        )
+        val firstOwner = store.authoritySnapshot().owner
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_newer", firstOwner),
+        )
+
+        assertEquals(
+            AuthorityMutationResult.Stale,
+            store.saveActiveResult("Scan_stale", firstOwner),
+        )
+        assertEquals(AuthorityMutationResult.Stale, store.clearActiveResult(firstOwner))
+        assertEquals("Scan_newer", store.activeResultCacheId())
+    }
+
+    @Test
+    fun newerVmLeaseInvalidatesOlderVmWithTheSameCheckpointValue() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val initialOwner = store.authoritySnapshot().owner
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_shared", initialOwner),
+        )
+        val oldVmOwner = initialOwner.withCheckpoint(ActiveResultCheckpoint("Scan_shared"))
+        val newVmOwner = store.authoritySnapshot().owner
+
+        assertEquals(
+            AuthorityMutationResult.Stale,
+            store.trySave(AppSettings(savePdf = false), oldVmOwner),
+        )
+        assertEquals(AuthorityMutationResult.Stale, store.clearActiveResult(oldVmOwner))
+        assertEquals(
+            AppearanceCommitResult.Stale,
+            store.saveAppliedAppearanceAndActiveResult(
+                ScanAppearanceSettings(colorMode = ScanColorMode.Color),
+                PdfSizeTarget.Mb5,
+                "Scan_stale",
+                oldVmOwner,
+            ),
+        )
+        assertEquals(AuthorityMutationResult.Applied, store.clearActiveResult(newVmOwner))
+    }
+
+    @Test
+    fun staleSettingsAndAppearanceApplyCannotOverwriteNewerAuthority() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val original = store.authoritySnapshot()
+        val staleAppearance =
+            ScanAppearanceSettings(colorMode = ScanColorMode.Color, colorIntensity = 12)
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_newer", original.owner),
+        )
+
+        assertEquals(
+            AuthorityMutationResult.Stale,
+            store.trySave(
+                original.settings.copy(appearance = staleAppearance),
+                original.owner,
+            ),
+        )
+        assertEquals(
+            AppearanceCommitResult.Stale,
+            store.saveAppliedAppearanceAndActiveResult(
+                staleAppearance,
+                PdfSizeTarget.Mb10,
+                "Scan_stale",
+                original.owner,
+            ),
+        )
+        assertEquals(ScanAppearanceSettings(), store.load().appearance)
+        assertEquals("Scan_newer", store.activeResultCacheId())
+    }
+
+    @Test
+    fun authoritySnapshotBlocksCheckpointMutationUntilRestoreWorkCompletes() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val restoreEntered = CountDownLatch(1)
+        val releaseRestore = CountDownLatch(1)
+        val writerStarted = CountDownLatch(1)
+        val writerFinished = CountDownLatch(1)
+        val writerResult = AtomicReference<AuthorityMutationResult>()
+        val restoreOwner = AtomicReference<ActiveResultOwner>()
+        val initialOwner = store.authoritySnapshot().owner
+
+        val restore =
+            thread {
+                store.withAuthoritySnapshot { snapshot ->
+                    restoreOwner.set(snapshot.owner)
+                    restoreEntered.countDown()
+                    releaseRestore.await(5, TimeUnit.SECONDS)
+                }
+            }
+        assertTrue(restoreEntered.await(5, TimeUnit.SECONDS))
+        assertEquals(
+            AuthorityMutationResult.Busy,
+            store.trySave(AppSettings(), initialOwner),
+        )
+        val writer =
+            thread {
+                writerStarted.countDown()
+                writerResult.set(store.saveActiveResult("Scan_newer", restoreOwner.get()))
+                writerFinished.countDown()
+            }
+        assertTrue(writerStarted.await(5, TimeUnit.SECONDS))
+        assertFalse(writerFinished.await(100, TimeUnit.MILLISECONDS))
+
+        releaseRestore.countDown()
+        restore.join(5_000)
+        writer.join(5_000)
+
+        assertFalse(restore.isAlive)
+        assertFalse(writer.isAlive)
+        assertEquals(AuthorityMutationResult.Applied, writerResult.get())
+    }
+
+    @Test
+    fun settingsScreenClosesOnlyAfterAnAppliedSave() {
+        assertTrue(settingsSaveApplied(AuthorityMutationResult.Applied))
+        assertFalse(settingsSaveApplied(AuthorityMutationResult.Busy))
+        assertFalse(settingsSaveApplied(AuthorityMutationResult.Stale))
+    }
+
+    @Test
+    fun activeResultCleanupRunsOnlyAfterCheckpointClear() {
+        val operations = mutableListOf<String>()
+
+        val result = clearActiveResultAndReconcileProvisionals(
+            clearCheckpoint = {
+                operations += "clear"
+                AuthorityMutationResult.Applied
+            },
+            reconcileProvisionals = { operations += "reconcile" },
+        )
+
+        assertEquals(AuthorityMutationResult.Applied, result)
+        assertEquals(listOf("clear", "reconcile"), operations)
+    }
+
+    @Test
+    fun staleCheckpointClearDoesNotReconcileProvisionals() {
+        var reconciled = false
+
+        val result =
+            clearActiveResultAndReconcileProvisionals(
+                clearCheckpoint = { AuthorityMutationResult.Stale },
+                reconcileProvisionals = { reconciled = true },
+            )
+
+        assertEquals(AuthorityMutationResult.Stale, result)
+        assertFalse(reconciled)
+    }
+
+    @Test
+    fun checkpointClearKeepsAuthorityUntilProvisionalReconciliationCompletes() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val initialOwner = store.authoritySnapshot().owner
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_old", initialOwner),
+        )
+        val oldOwner = store.authoritySnapshot().owner
+        val reconciliationEntered = CountDownLatch(1)
+        val releaseReconciliation = CountDownLatch(1)
+        val writerFinished = CountDownLatch(1)
+        val writerResult = AtomicReference<AuthorityMutationResult>()
+
+        val cleanup =
+            thread {
+                clearActiveResultAndReconcileProvisionals(
+                    clearCheckpoint = { store.clearActiveResult(oldOwner) },
+                    reconcileProvisionals = {
+                        reconciliationEntered.countDown()
+                        releaseReconciliation.await(5, TimeUnit.SECONDS)
+                    },
+                )
+            }
+        assertTrue(reconciliationEntered.await(5, TimeUnit.SECONDS))
+        val writer =
+            thread {
+                writerResult.set(
+                    store.saveActiveResult("Scan_newer", oldOwner.withCheckpoint(null)),
+                )
+                writerFinished.countDown()
+            }
+        assertFalse(writerFinished.await(100, TimeUnit.MILLISECONDS))
+
+        releaseReconciliation.countDown()
+        cleanup.join(5_000)
+        writer.join(5_000)
+
+        assertFalse(cleanup.isAlive)
+        assertFalse(writer.isAlive)
+        assertEquals(AuthorityMutationResult.Applied, writerResult.get())
+        assertEquals("Scan_newer", store.activeResultCacheId())
+    }
+
+    @Test
+    fun reconciliationFailureIsReportedAsPostCheckpointCleanup() {
+        val failure = IOException("provider failed")
+
+        val thrown =
+            assertThrows(ActiveResultCleanupException::class.java) {
+                clearActiveResultAndReconcileProvisionals(
+                    clearCheckpoint = { AuthorityMutationResult.Applied },
+                    reconcileProvisionals = { throw failure },
+                )
+            }
+
+        assertSame(failure, thrown.cause)
+    }
+
+    @Test
+    fun checkpointClearFailureDoesNotStartProvisionalCleanup() {
+        var reconciled = false
+
+        assertThrows(IOException::class.java) {
+            clearActiveResultAndReconcileProvisionals(
+                clearCheckpoint = { throw IOException("checkpoint failed") },
+                reconcileProvisionals = { reconciled = true },
+            )
+        }
+
+        assertFalse(reconciled)
+    }
+
+    @Test
+    fun failedRestoreKeepsAnAuthoritativeProvisionalCheckpointForRetry() {
+        assertTrue(keepCheckpointAfterRestoreFailure(authoritativeWasProvisional = true))
+        assertFalse(keepCheckpointAfterRestoreFailure(authoritativeWasProvisional = false))
+    }
+
+    @Test
+    fun onlyProvisionalV3CheckpointRepairsAppearancePreferences() {
+        val newerDefaults =
+            AppSettings(
+                appearance = ScanAppearanceSettings(colorMode = ScanColorMode.Color),
+                pdfSizeTarget = PdfSizeTarget.Mb20,
+            )
+        val cachedDefaults =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Grayscale,
+                grayscaleIntensity = 25,
+            )
+        val authoritative =
+            CachedScan(
+                baseName = "Scan_candidate",
+                pages = listOf(File("page.jpg")),
+                pdf = File("scan.pdf"),
+                appearanceSettings = cachedDefaults,
+                pdfSizeTarget = PdfSizeTarget.Mb5,
+            )
+
+        assertEquals(
+            newerDefaults,
+            checkpointRestoreSettings(newerDefaults, authoritative, provisional = false),
+        )
+        assertEquals(
+            newerDefaults.copy(
+                appearance = cachedDefaults,
+                pdfSizeTarget = PdfSizeTarget.Mb5,
+            ),
+            checkpointRestoreSettings(newerDefaults, authoritative, provisional = true),
+        )
+    }
+
+    @Test
+    fun appearanceRestoreRequiresCurrentCheckpointOwnership() {
+        val (preferences, _) = inMemoryPreferences()
+        val store = SettingsStore(preferences, "Scanned document")
+        val initialOwner = store.authoritySnapshot().owner
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_candidate", initialOwner),
+        )
+        val owner = initialOwner.withCheckpoint(ActiveResultCheckpoint("Scan_candidate"))
+        val appearance =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Grayscale,
+                grayscaleIntensity = 22,
+                shadows = 44,
+            )
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.restoreAppearanceAuthority(appearance, PdfSizeTarget.Mb5, owner),
+        )
+        assertEquals(appearance, store.load().appearance)
+        assertEquals(PdfSizeTarget.Mb5, store.load().pdfSizeTarget)
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            store.saveActiveResult("Scan_newer", owner),
+        )
+        assertEquals(
+            AuthorityMutationResult.Stale,
+            store.restoreAppearanceAuthority(ScanAppearanceSettings(), PdfSizeTarget.Original, owner),
+        )
+        assertEquals(appearance, store.load().appearance)
+        assertEquals("Scan_newer", store.activeResultCacheId())
+    }
+
+    @Test
+    fun fullSettingsSaveIsBlockedWhileAppearanceCommitRuns() {
+        val applying =
+            ScreenState.Result(
+                scan =
+                    SavedScan(
+                        cached = CachedScan("Scan_1", emptyList(), File("Scan_1.pdf")),
+                        galleryPages = emptyList(),
+                        savedPdf = null,
+                    ),
+                thumbnail = null,
+                appearanceApplyInProgress = true,
+            )
+
+        assertFalse(settingsSaveAllowed(applying))
+        assertTrue(settingsSaveAllowed(applying.copy(appearanceApplyInProgress = false)))
+        assertTrue(settingsSaveAllowed(ScreenState.Ready))
+    }
+
+    @Test
+    fun emailLocalizationDoesNotRewriteAppearanceTransactionKeys() {
+        val (preferences, values) = inMemoryPreferences()
+        values["appearance_mode"] = "black_white"
+        values["appearance_shadows"] = 50
+        values["active_result_checkpoint"] = "1:Scan_current"
+
+        SettingsStore(preferences, "Scanned document").saveEmailSubject("Localized subject")
+
+        assertEquals("Localized subject", values["email_subject"])
+        assertEquals("black_white", values["appearance_mode"])
+        assertEquals(50, values["appearance_shadows"])
+        assertEquals("1:Scan_current", values["active_result_checkpoint"])
     }
 
     @Test
@@ -417,8 +930,8 @@ class PureLogicTest {
     }
 
     @Test
-    fun scannerPageLimitOnlyDisablesMultipageCapture() {
-        assertEquals(null, scannerPageLimit(multipage = true))
+    fun scannerPageLimitBoundsMultipageCapture() {
+        assertEquals(20, scannerPageLimit(multipage = true))
         assertEquals(1, scannerPageLimit(multipage = false))
     }
 
@@ -780,9 +1293,29 @@ class PureLogicTest {
         assertNull(decodeActiveResultCheckpoint("1:C:outside"))
         assertNull(decodeActiveResultCheckpoint("1:Scan\u0000outside"))
         assertNull(decodeActiveResultCheckpoint("1:${"a".repeat(129)}"))
+        assertNull(
+            decodeActiveResultCheckpointPayload(
+                "2:$cacheId:color:101:50:50:50",
+            ),
+        )
+        assertNull(
+            decodeActiveResultCheckpointPayload(
+                "2:$cacheId:future:50:50:50:50",
+            ),
+        )
         assertThrows(IllegalArgumentException::class.java) {
             encodeActiveResultCheckpoint("../outside")
         }
+    }
+
+    @Test
+    fun malformedDurableCheckpointIsRetainedForFailClosedRecovery() {
+        val (preferences, values) = inMemoryPreferences()
+        values["active_result_checkpoint"] = "2:malformed"
+        val store = SettingsStore(preferences, "Scanned document")
+
+        assertThrows(IOException::class.java) { store.activeResultCheckpoint() }
+        assertEquals("2:malformed", values["active_result_checkpoint"])
     }
 
     @Test
@@ -895,8 +1428,42 @@ class PureLogicTest {
             appBackAction(settingsOpen = true, fileDetailsOpen = true, state = result),
         )
         assertEquals(
+            AppBackAction.CollapseAppearance,
+            appBackAction(
+                settingsOpen = false,
+                fileDetailsOpen = true,
+                state = result,
+                appearanceOpen = true,
+            ),
+        )
+        assertEquals(
             AppBackAction.CollapseFileDetails,
             appBackAction(settingsOpen = false, fileDetailsOpen = true, state = result),
+        )
+    }
+
+    @Test
+    fun backNavigationIsConsumedWhileAppearanceIsApplying() {
+        val result =
+            ScreenState.Result(
+                scan =
+                    SavedScan(
+                        cached = CachedScan("Scan_1", emptyList(), File("Scan_1.pdf")),
+                        galleryPages = emptyList(),
+                        savedPdf = null,
+                    ),
+                thumbnail = null,
+                appearanceApplyInProgress = true,
+            )
+
+        assertEquals(
+            AppBackAction.Consume,
+            appBackAction(
+                settingsOpen = false,
+                fileDetailsOpen = true,
+                state = result,
+                appearanceOpen = true,
+            ),
         )
     }
 
@@ -1133,8 +1700,12 @@ class PureLogicTest {
             outputMetadataValid = outputMetadataValid,
         )
 
-    private fun inMemoryPreferences(): Pair<SharedPreferences, MutableMap<String, Any?>> {
+    private fun inMemoryPreferences(
+        commitResults: List<Boolean> = emptyList(),
+        afterCommit: (Int, MutableMap<String, Any?>) -> Unit = { _, _ -> },
+    ): Pair<SharedPreferences, MutableMap<String, Any?>> {
         val values = mutableMapOf<String, Any?>()
+        var commitIndex = 0
         lateinit var editor: SharedPreferences.Editor
         editor =
             Proxy.newProxyInstance(
@@ -1142,10 +1713,15 @@ class PureLogicTest {
                 arrayOf(SharedPreferences.Editor::class.java),
             ) { _, method, args ->
                 when (method.name) {
-                    "putBoolean", "putString" -> editor.also { values[args!![0] as String] = args[1] }
+                    "putBoolean", "putString", "putInt" ->
+                        editor.also { values[args!![0] as String] = args[1] }
                     "remove" -> editor.also { values.remove(args!![0] as String) }
                     "apply" -> null
-                    "commit" -> true
+                    "commit" -> {
+                        val index = commitIndex++
+                        afterCommit(index, values)
+                        commitResults.getOrElse(index) { true }
+                    }
                     else -> throw UnsupportedOperationException(method.name)
                 }
             } as SharedPreferences.Editor
@@ -1162,7 +1738,11 @@ class PureLogicTest {
                     "getString" ->
                         values[key]?.let { it as? String ?: throw ClassCastException() }
                             ?: args!![1] as String?
+                    "getInt" ->
+                        values[key]?.let { it as? Int ?: throw ClassCastException() }
+                            ?: args!![1] as Int
                     "contains" -> values.containsKey(key)
+                    "getAll" -> values.toMap()
                     "edit" -> editor
                     else -> throw UnsupportedOperationException(method.name)
                 }

--- a/app/src/test/java/com/majkeylab/scanit/RecentScanTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/RecentScanTest.kt
@@ -17,6 +17,20 @@ import org.junit.Test
 
 class RecentScanTest {
     @Test
+    fun sourcePageFileNamesAreStableAndRejectInvalidInput() {
+        val id = "Scan_2026-08-09_10-20-30"
+
+        assertEquals("${id}_source_01.jpg", scanSourcePageFileName(id, 1))
+        assertEquals("${id}_source_12.jpg", scanSourcePageFileName(id, 12))
+        assertThrows(IllegalArgumentException::class.java) {
+            scanSourcePageFileName(id, 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            scanSourcePageFileName("", 1)
+        }
+    }
+
+    @Test
     fun validFolderProducesRecentEntryAndOrderedCachedScan() = withShareRoot { root ->
         val id = "Scan_2026-08-09_10-20-30"
         val directory = createEntry(root, id, pageCount = 10, pdfBytes = byteArrayOf(1, 2, 3))
@@ -33,10 +47,63 @@ class RecentScanTest {
         assertEquals("${id}_01.jpg", recent.firstPage.name)
         assertEquals((1..10).map { scanPageFileName(id, it) }, cached.pages.map(File::getName))
         assertEquals(scanPdfFileName(id), cached.pdf.name)
+        assertEquals(emptyList<File>(), cached.sourcePages)
         assertNull(recent.entryId)
         assertFalse(recent.hasSavedPdf)
         assertEquals(0, recent.savedImageCount)
         assertNull(cached.entryId)
+    }
+
+    @Test
+    fun completeSourceSetProducesOrderedImmutableSourcePages() = withShareRoot { root ->
+        val id = "Scan_with_sources"
+        createEntry(root, id, pageCount = 3, sourcePageCount = 3)
+
+        val cached = openCachedScanInRoot(root, id)!!
+
+        assertEquals(
+            (1..3).map { scanSourcePageFileName(id, it) },
+            cached.sourcePages.map(File::getName),
+        )
+        assertEquals(ScanAppearance(), cached.appearance)
+    }
+
+    @Test
+    fun sourceSetMustMatchEveryCanonicalPage() = withShareRoot { root ->
+        createEntry(root, "Scan_source_gap", pageCount = 3, sourcePageCount = 3).apply {
+            assertTrue(File(this, scanSourcePageFileName(name, 2)).delete())
+        }
+        createEntry(root, "Scan_source_short", pageCount = 3, sourcePageCount = 2)
+        createEntry(root, "Scan_source_extra", pageCount = 2, sourcePageCount = 3)
+
+        assertEquals(emptyList<RecentScan>(), listRecentScansInRoot(root))
+    }
+
+    @Test
+    fun malformedEmptyAndDuplicateSourceLookalikesAreRejected() = withShareRoot { root ->
+        val malformed = "Scan_source_malformed"
+        createEntry(root, malformed).apply {
+            File(this, "${malformed}_source_1.jpg").writeBytes(byteArrayOf(1))
+        }
+        val empty = "Scan_source_empty"
+        createEntry(root, empty).apply {
+            File(this, scanSourcePageFileName(empty, 1)).writeBytes(byteArrayOf())
+        }
+        val duplicate = "Scan_source_duplicate"
+        createEntry(root, duplicate, sourcePageCount = 1).apply {
+            File(this, "${duplicate}_source_001.jpg").writeBytes(byteArrayOf(1))
+        }
+
+        assertEquals(emptyList<RecentScan>(), listRecentScansInRoot(root))
+    }
+
+    @Test
+    fun deletingSourceBackedEntryRemovesItsWholeCache() = withShareRoot { root ->
+        val id = "Scan_source_delete"
+        val directory = createEntry(root, id, pageCount = 2, sourcePageCount = 2)
+
+        assertTrue(deleteRecentScanInRoot(root, id))
+        assertFalse(directory.exists())
     }
 
     @Test
@@ -275,6 +342,462 @@ class RecentScanTest {
         assertTrue(File(finalDirectory, OUTPUT_METADATA_FILE_NAME).isFile)
         assertEquals(listOf(finalId), listRecentScansInRoot(root).map(RecentScan::cacheId))
     }
+
+    @Test
+    fun provisionalPublishAtCapacityCanBeRolledBackWithoutPruningHistory() =
+        withShareRoot { root ->
+            val oldIds =
+                (1..8).map { index ->
+                    "Scan_old_$index".also { id ->
+                        createEntry(root, id).apply { assertTrue(setLastModified(index.toLong())) }
+                    }
+                }
+            val finalId = "Scan_candidate"
+            val pending = createEntry(root, ".pending-candidate", fileBaseName = finalId)
+            val cache = RecentScanCache(root)
+
+            val candidate = cache.publishProvisional(pending, File(root, finalId))
+
+            assertEquals(oldIds.toSet(), cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet())
+            assertEquals(finalId, cache.open(finalId)?.baseName)
+            assertTrue(cache.delete(candidate.baseName))
+            assertEquals(oldIds.toSet(), cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet())
+            assertEquals(oldIds.toSet(), root.listFiles()!!.map(File::getName).toSet())
+        }
+
+    @Test
+    fun provisionalDeleteRejectsAnotherEntryGeneration() =
+        withShareRoot { root ->
+            val finalId = "Scan_candidate"
+            val pending = createEntry(root, ".pending-candidate", fileBaseName = finalId)
+            val cache = RecentScanCache(root)
+            val candidate = cache.publishProvisional(pending, File(root, finalId))
+
+            assertFalse(
+                cache.deleteProvisional(
+                    finalId,
+                    "123e4567-e89b-12d3-a456-426614174000",
+                ),
+            )
+            assertTrue(File(root, finalId).isDirectory)
+            assertTrue(cache.deleteProvisional(finalId, checkNotNull(candidate.entryId)))
+            assertFalse(File(root, finalId).exists())
+        }
+
+    @Test
+    fun exactDeleteRejectsAnotherEntryGeneration() =
+        withShareRoot { root ->
+            val cacheId = "Scan_candidate"
+            val cache = RecentScanCache(root)
+            val candidate =
+                cache.publish(
+                    createEntry(root, ".pending-candidate", fileBaseName = cacheId),
+                    File(root, cacheId),
+                )
+            val entryId = checkNotNull(candidate.entryId)
+
+            assertFalse(
+                cache.deleteExact(
+                    cacheId,
+                    "123e4567-e89b-12d3-a456-426614174000",
+                ),
+            )
+            assertTrue(File(root, cacheId).isDirectory)
+            assertTrue(cache.deleteExact(cacheId, entryId))
+            assertFalse(File(root, cacheId).exists())
+        }
+
+    @Test
+    fun failedProvisionalPublishCleansPendingWithoutTouchingExistingFinalEntry() =
+        withShareRoot { root ->
+            val finalId = "Scan_existing"
+            val finalDirectory = createEntry(root, finalId)
+            val pending = createEntry(root, ".pending-candidate", fileBaseName = finalId)
+
+            assertThrows(IOException::class.java) {
+                RecentScanCache(root).publishProvisional(pending, finalDirectory)
+            }
+
+            assertFalse(pending.exists())
+            assertTrue(finalDirectory.isDirectory)
+            assertEquals(listOf(finalId), listRecentScansInRoot(root).map(RecentScan::cacheId))
+        }
+
+    @Test
+    fun activationRetiresOnlyRequestedRevisionAfterExplicitActivation() =
+        withShareRoot { root ->
+            val lineageId = "Scan_lineage"
+            val oldIds =
+                (1..8).map { index ->
+                    "Scan_old_$index".also { id ->
+                        createEntry(root, id).apply {
+                            assertTrue(setLastModified(index.toLong()))
+                            if (index == 1) {
+                                writeLegacyAppearanceMetadata(this, lineageId)
+                            }
+                        }
+                    }
+                }
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(root, ".pending-candidate", fileBaseName = finalId).apply {
+                    writeLegacyAppearanceMetadata(this, lineageId)
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+            assertEquals(oldIds.toSet(), cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet())
+
+            val activated =
+                cache.activateProvisional(
+                    candidateCacheId = finalId,
+                    retireCacheId = oldIds.first(),
+                    maxEntries = 8,
+                )
+
+            assertEquals(finalId, activated.baseName)
+            assertEquals(
+                (oldIds.drop(1) + finalId).toSet(),
+                cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet(),
+            )
+            assertFalse(File(root, oldIds.first()).exists())
+        }
+
+    @Test
+    fun activationRejectsRetiringAnUnrelatedLineage() =
+        withShareRoot { root ->
+            val oldId = "Scan_unrelated"
+            createEntry(root, oldId)
+            val finalId = "Scan_candidate"
+            val pending = createEntry(root, ".pending-candidate", fileBaseName = finalId)
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+
+            assertThrows(IOException::class.java) {
+                cache.activateProvisional(
+                    candidateCacheId = finalId,
+                    retireCacheId = oldId,
+                )
+            }
+
+            assertTrue(cache.isProvisional(finalId))
+            assertTrue(File(root, oldId).isDirectory)
+            assertEquals(listOf(oldId), cache.list().map(RecentScan::cacheId))
+        }
+
+    @Test
+    fun failedActivationKeepsCandidateProvisionalAndRestoresEveryPriorEntry() =
+        withShareRoot { root ->
+            val lineageId = "Scan_lineage"
+            val oldIds =
+                (1..3).map { index ->
+                    "Scan_old_$index".also { id ->
+                        createEntry(root, id).apply {
+                            assertTrue(setLastModified(index.toLong()))
+                            if (index == 1) {
+                                writeLegacyAppearanceMetadata(this, lineageId)
+                            }
+                        }
+                    }
+                }
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(root, ".pending-candidate", fileBaseName = finalId).apply {
+                    writeLegacyAppearanceMetadata(this, lineageId)
+                }
+            var failActivationMove = true
+            val cache =
+                RecentScanCache(
+                    root,
+                    moveEntry = { source, target ->
+                        Files.move(source, target, StandardCopyOption.ATOMIC_MOVE)
+                        if (
+                            failActivationMove &&
+                                target.parent.fileName.toString().startsWith(".pending-recovery-")
+                        ) {
+                            failActivationMove = false
+                            throw IOException("Forced activation move failure")
+                        }
+                    },
+                )
+            cache.publishProvisional(pending, File(root, finalId))
+
+            assertThrows(IOException::class.java) {
+                cache.activateProvisional(
+                    candidateCacheId = finalId,
+                    retireCacheId = oldIds.first(),
+                    maxEntries = 3,
+                )
+            }
+
+            assertTrue(File(root, finalId).isDirectory)
+            assertTrue(cache.isProvisional(finalId))
+            assertEquals(oldIds.toSet(), cache.list(maxEntries = 3).map(RecentScan::cacheId).toSet())
+            assertEquals(
+                oldIds.toSet() + finalId,
+                root.listFiles()!!.map(File::getName).toSet(),
+            )
+        }
+
+    @Test
+    fun startupRecoveryKeepsProvisionalCheckpointWhenActivationMarkerWasNotWritten() =
+        withShareRoot { root ->
+            val oldId = "Scan_old"
+            createEntry(root, oldId)
+            val finalId = "Scan_candidate"
+            val pending = createEntry(root, ".pending-candidate", fileBaseName = finalId)
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+            assertTrue(File(root, ".pending-recovery-$finalId").mkdir())
+
+            assertEquals(listOf(oldId), cache.list().map(RecentScan::cacheId))
+
+            assertTrue(cache.isProvisional(finalId))
+            assertEquals(finalId, cache.open(finalId)?.baseName)
+            assertFalse(File(root, ".pending-recovery-$finalId").exists())
+        }
+
+    @Test
+    fun checkpointRecoveryRetiresTheOnlyVisibleRevisionWithTheSameLineage() =
+        withShareRoot { root ->
+            val lineageId = "Scan_lineage"
+            val oldId = "Scan_old"
+            val oldEntryId = "00000000-0000-0000-0000-000000000001"
+            createEntry(root, oldId, sourcePageCount = 1).also { directory ->
+                initializeOutputMetadata(directory, oldId, 1, 1L, oldEntryId)
+                writeLegacyAppearanceMetadata(directory, lineageId)
+            }
+            val unrelatedId = "Scan_unrelated"
+            createEntry(root, unrelatedId)
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-candidate",
+                    sourcePageCount = 1,
+                    fileBaseName = finalId,
+                ).also { directory ->
+                    writeScanAppearanceMetadata(
+                        directory,
+                        ScanAppearanceSettings(),
+                        lineageCacheId = lineageId,
+                        parentCacheId = oldId,
+                        parentEntryId = oldEntryId,
+                    )
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+            assertTrue(cache.isProvisional(finalId))
+
+            val recovered = cache.activateCheckpointProvisional(finalId)
+
+            assertEquals(finalId, recovered.baseName)
+            assertFalse(cache.isProvisional(finalId))
+            assertEquals(
+                setOf(finalId, unrelatedId),
+                cache.list().map(RecentScan::cacheId).toSet(),
+            )
+            assertFalse(File(root, oldId).exists())
+            assertEquals(finalId, cache.activateCheckpointProvisional(finalId).baseName)
+        }
+
+    @Test
+    fun checkpointRecoveryActivatesWhenThePriorLineageRevisionIsAlreadyGone() =
+        withShareRoot { root ->
+            val unrelatedId = "Scan_unrelated"
+            createEntry(root, unrelatedId)
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-candidate",
+                    sourcePageCount = 1,
+                    fileBaseName = finalId,
+                ).apply {
+                    writeScanAppearanceMetadata(
+                        this,
+                        ScanAppearanceSettings(),
+                        lineageCacheId = "Scan_gone",
+                        parentCacheId = "Scan_gone",
+                        parentEntryId = "00000000-0000-0000-0000-000000000001",
+                    )
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+
+            val recovered = cache.activateCheckpointProvisional(finalId)
+
+            assertEquals(finalId, recovered.baseName)
+            assertFalse(cache.isProvisional(finalId))
+            assertEquals(
+                setOf(finalId, unrelatedId),
+                cache.list().map(RecentScan::cacheId).toSet(),
+            )
+        }
+
+    @Test
+    fun checkpointRecoveryRetiresOnlyExactUnsavedParentAndKeepsSavedHistory() =
+        withShareRoot { root ->
+            val lineageId = "Scan_lineage"
+            val savedId = "Scan_saved"
+            val savedEntryId = "00000000-0000-0000-0000-000000000001"
+            createEntry(root, savedId, sourcePageCount = 1).apply {
+                initializeOutputMetadata(this, savedId, 1, 1L, savedEntryId)
+                rewriteOutputMetadata(this, savedId, savedEntryId, 1) {
+                    it.copy(
+                        images =
+                            listOf(
+                                ImageOutputRef(
+                                    page = 1,
+                                    uri = "content://media/external/images/media/1",
+                                ),
+                            ),
+                    )
+                }
+                writeLegacyAppearanceMetadata(this, lineageId)
+            }
+            val parentId = "Scan_parent"
+            val parentEntryId = "00000000-0000-0000-0000-000000000002"
+            createEntry(root, parentId, sourcePageCount = 1).apply {
+                initializeOutputMetadata(this, parentId, 1, 2L, parentEntryId)
+                writeLegacyAppearanceMetadata(
+                    this,
+                    lineageId,
+                    ScanAppearance(colorMode = ScanColorMode.Grayscale),
+                )
+            }
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-candidate",
+                    sourcePageCount = 1,
+                    fileBaseName = finalId,
+                ).apply {
+                    writeScanAppearanceMetadata(
+                        this,
+                        ScanAppearanceSettings(colorMode = ScanColorMode.Color),
+                        lineageCacheId = lineageId,
+                        parentCacheId = parentId,
+                        parentEntryId = parentEntryId,
+                    )
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+
+            val activated = cache.activateCheckpointProvisional(finalId)
+
+            assertEquals(finalId, activated.baseName)
+            assertFalse(cache.isProvisional(finalId))
+            assertFalse(File(root, parentId).exists())
+            assertTrue(File(root, savedId).isDirectory)
+            assertEquals(
+                setOf(savedId, finalId),
+                cache.list().map(RecentScan::cacheId).toSet(),
+            )
+        }
+
+    @Test
+    fun checkpointRecoveryPreservesParentWithAnyDurableRefOrStaleGeneration() =
+        withShareRoot { root ->
+            val lineageId = "Scan_lineage"
+            val parentId = "Scan_parent"
+            val parentEntryId = "00000000-0000-0000-0000-000000000001"
+            createEntry(root, parentId, sourcePageCount = 1).apply {
+                initializeOutputMetadata(this, parentId, 1, 1L, parentEntryId)
+                rewriteOutputMetadata(this, parentId, parentEntryId, 1) {
+                    it.copy(
+                        pdf = PdfOutputRef("content://media/external/downloads/1", null),
+                    )
+                }
+                writeLegacyAppearanceMetadata(this, lineageId)
+            }
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-candidate",
+                    sourcePageCount = 1,
+                    fileBaseName = finalId,
+                ).apply {
+                    writeScanAppearanceMetadata(
+                        this,
+                        ScanAppearanceSettings(),
+                        lineageCacheId = lineageId,
+                        parentCacheId = parentId,
+                        parentEntryId = parentEntryId,
+                    )
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+
+            assertEquals(finalId, cache.activateCheckpointProvisional(finalId).baseName)
+            assertTrue(File(root, parentId).isDirectory)
+            assertEquals(
+                setOf(parentId, finalId),
+                cache.list().map(RecentScan::cacheId).toSet(),
+            )
+        }
+
+    @Test
+    fun legacyV2ProvisionalCannotBecomeCheckpointAuthority() =
+        withShareRoot { root ->
+            val finalId = "Scan_candidate"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-candidate",
+                    sourcePageCount = 1,
+                    fileBaseName = finalId,
+                ).apply {
+                    File(this, SCAN_APPEARANCE_FILE_NAME).writeText(
+                        "scanit-appearance-v2\nblack_white\n100\n50\noriginal\n$finalId\n",
+                        Charsets.US_ASCII,
+                    )
+                }
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(pending, File(root, finalId))
+
+            assertThrows(IOException::class.java) {
+                cache.activateCheckpointProvisional(finalId)
+            }
+
+            assertTrue(cache.isProvisional(finalId))
+        }
+
+    @Test
+    fun provisionalReconciliationKeepsOnlyTheAuthoritativeCandidate() =
+        withShareRoot { root ->
+            val activeId = "Scan_active"
+            createEntry(root, activeId)
+            val authoritativeId = "Scan_authoritative"
+            val orphanId = "Scan_orphan"
+            val cache = RecentScanCache(root)
+            cache.publishProvisional(
+                createEntry(root, ".pending-authoritative", fileBaseName = authoritativeId),
+                File(root, authoritativeId),
+            )
+            cache.publishProvisional(
+                createEntry(root, ".pending-orphan", fileBaseName = orphanId),
+                File(root, orphanId),
+            )
+
+            assertThrows(IOException::class.java) {
+                cache.reconcileProvisionals(activeId)
+            }
+            assertTrue(File(root, authoritativeId).isDirectory)
+            assertTrue(File(root, orphanId).isDirectory)
+
+            cache.reconcileProvisionals(authoritativeId)
+
+            assertTrue(cache.isProvisional(authoritativeId))
+            assertFalse(File(root, orphanId).exists())
+            assertEquals(listOf(activeId), cache.list().map(RecentScan::cacheId))
+
+            cache.reconcileProvisionals(null)
+
+            assertFalse(File(root, authoritativeId).exists())
+            assertEquals(listOf(activeId), cache.list().map(RecentScan::cacheId))
+        }
 
     @Test
     fun pruningNeverDeletesDurableOutputsOutsideTheCache() = withShareRoot { root ->
@@ -635,6 +1158,7 @@ class RecentScanTest {
         root: File,
         directoryName: String,
         pageCount: Int = 1,
+        sourcePageCount: Int = 0,
         pdfBytes: ByteArray = byteArrayOf(1),
         fileBaseName: String = directoryName,
     ): File =
@@ -644,7 +1168,34 @@ class RecentScanTest {
             (pageCount downTo 1).forEach { page ->
                 File(this, scanPageFileName(fileBaseName, page)).writeBytes(byteArrayOf(page.toByte()))
             }
+            (sourcePageCount downTo 1).forEach { page ->
+                File(this, scanSourcePageFileName(fileBaseName, page))
+                    .writeBytes(byteArrayOf(page.toByte()))
+            }
+            if (sourcePageCount > 0) {
+                writeScanAppearanceMetadata(
+                    this,
+                    ScanAppearanceSettings(),
+                    lineageCacheId = fileBaseName,
+                )
+            }
         }
+
+    private fun writeLegacyAppearanceMetadata(
+        directory: File,
+        lineageCacheId: String,
+        appearance: ScanAppearance = ScanAppearance(),
+    ) {
+        File(directory, SCAN_APPEARANCE_FILE_NAME).writeText(
+            "scanit-appearance-v2\n" +
+                "${appearance.colorMode.wireValue}\n" +
+                "${appearance.intensity}\n" +
+                "${appearance.shadows}\n" +
+                "original\n" +
+                "$lineageCacheId\n",
+            Charsets.US_ASCII,
+        )
+    }
 
     private fun withShareRoot(block: (File) -> Unit) {
         val root = Files.createTempDirectory("recent-scans").toFile()

--- a/app/src/test/java/com/majkeylab/scanit/ScanAppearanceMetadataTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/ScanAppearanceMetadataTest.kt
@@ -1,0 +1,99 @@
+package com.majkeylab.scanit
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScanAppearanceMetadataTest {
+    @Test
+    fun v3MetadataRoundTripsFullNormalizedSettingsAndExactParent() {
+        val settings =
+            ScanAppearanceSettings(
+                colorMode = ScanColorMode.Grayscale,
+                colorIntensity = 140,
+                grayscaleIntensity = 35,
+                blackWhiteIntensity = -5,
+                shadows = 45,
+            )
+        val encoded =
+            encodeScanAppearanceMetadata(
+                settings,
+                PdfSizeTarget.Mb5,
+                "Scan_origin",
+                parentCacheId = "Scan_parent",
+                parentEntryId = "00000000-0000-0000-0000-000000000001",
+            )
+
+        assertEquals(
+            ScanAppearanceMetadata(
+                appearance =
+                    ScanAppearance(ScanColorMode.Grayscale, intensity = 35, shadows = 45),
+                appearanceSettings =
+                    settings.copy(
+                        colorIntensity = 100,
+                        blackWhiteIntensity = 0,
+                    ),
+                pdfSizeTarget = PdfSizeTarget.Mb5,
+                lineageCacheId = "Scan_origin",
+                parentCacheId = "Scan_parent",
+                parentEntryId = "00000000-0000-0000-0000-000000000001",
+            ),
+            decodeScanAppearanceMetadata(encoded),
+        )
+        assertNull(decodeScanAppearanceMetadata(encoded + "extra\n".toByteArray()))
+        assertNull(
+            decodeScanAppearanceMetadata(
+                encoded.toString(Charsets.US_ASCII)
+                    .replace("derived\nScan_parent\n", "derived\n../parent\n")
+                    .toByteArray(Charsets.US_ASCII),
+            ),
+        )
+    }
+
+    @Test
+    fun legacyV2RemainsReadableButCannotAuthorizeAProvisionalCandidate() {
+        val decoded =
+            decodeScanAppearanceMetadata(
+                "scanit-appearance-v2\ncolor\n70\n25\n10_mb\nScan_origin\n"
+                    .toByteArray(Charsets.US_ASCII),
+            )
+
+        assertEquals(ScanAppearance(ScanColorMode.Color, 70, 25), decoded?.appearance)
+        assertEquals(PdfSizeTarget.Mb10, decoded?.pdfSizeTarget)
+        assertEquals("Scan_origin", decoded?.lineageCacheId)
+        assertNull(decoded?.appearanceSettings)
+        assertNull(decoded?.parentCacheId)
+        assertNull(decoded?.parentEntryId)
+    }
+
+    @Test
+    fun writePublishesCompleteMetadataWithoutLeavingTemporaryFile() {
+        val directory = Files.createTempDirectory("scanit-appearance-metadata-").toFile()
+        try {
+            writeScanAppearanceMetadata(
+                directory,
+                ScanAppearanceSettings(),
+                PdfSizeTarget.Mb10,
+                "Scan_origin",
+            )
+
+            assertEquals(
+                ScanAppearanceMetadata(
+                    ScanAppearance(),
+                    ScanAppearanceSettings(),
+                    PdfSizeTarget.Mb10,
+                    "Scan_origin",
+                    parentCacheId = null,
+                    parentEntryId = null,
+                ),
+                readScanAppearanceMetadata(directory, "Scan_origin"),
+            )
+            assertFalse(File(directory, SCAN_APPEARANCE_TEMP_FILE_NAME).exists())
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+}

--- a/app/src/test/java/com/majkeylab/scanit/ScanAppearanceRendererTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/ScanAppearanceRendererTest.kt
@@ -31,6 +31,29 @@ class ScanAppearanceRendererTest {
         assertThrows(IllegalArgumentException::class.java) {
             sampledDimensionUpperBound(size = 1, sampleSize = 0)
         }
+        assertThrows(IllegalArgumentException::class.java) {
+            appearanceDecodeSampleSize(width = 100, height = 100, minimumSampleSize = 3)
+        }
+    }
+
+    @Test
+    fun requestedPowerOfTwoSamplingCanReduceAPdfCandidateFurther() {
+        assertEquals(
+            4,
+            appearanceDecodeSampleSize(
+                width = 2_480,
+                height = 3_508,
+                minimumSampleSize = 4,
+            ),
+        )
+        assertEquals(
+            4,
+            appearanceDecodeSampleSize(
+                width = 12_000,
+                height = 9_000,
+                minimumSampleSize = 2,
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/majkeylab/scanit/ScanPdfBuilderTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/ScanPdfBuilderTest.kt
@@ -1,0 +1,261 @@
+package com.majkeylab.scanit
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ScanPdfBuilderTest {
+    @Test
+    fun oversizedPageCountIsRejectedBeforeRenderingOrCreatingWorkingFiles() =
+        withTempDirectory { directory ->
+            val page =
+                ScanPdfBuildPage(
+                    longestEdge = 1,
+                    renderJpeg = { _, _ -> error("Page rendered before count validation") },
+                    createBitonal = { error("Bitonal page created before count validation") },
+                )
+
+            val failure =
+                assertThrows(IllegalArgumentException::class.java) {
+                    buildScanPdf(
+                        File(directory, "oversized.pdf"),
+                        List(MAX_SCAN_PAGES + 1) { page },
+                        PdfSizeTarget.Original,
+                        bitonalEligible = false,
+                    )
+                }
+
+            assertEquals("PDF page count exceeds $MAX_SCAN_PAGES", failure.message)
+            assertTrue(directory.listFiles()?.isEmpty() == true)
+        }
+
+    @Test
+    fun mixedPageSizesOnlyDownsamplePagesThatStayLegible() =
+        withTempDirectory { directory ->
+            val largeSamples = mutableListOf<Int>()
+            val smallSamples = mutableListOf<Int>()
+            val pages =
+                listOf(
+                    fakePage(directory, "large", longestEdge = 6_000) { sample ->
+                        largeSamples += sample
+                        if (sample == 1) 4 * MB else MB
+                    },
+                    fakePage(directory, "small", longestEdge = 1_000) { sample ->
+                        smallSamples += sample
+                        2 * MB
+                    },
+                )
+
+            val result =
+                buildScanPdf(
+                    File(directory, "mixed.pdf"),
+                    pages,
+                    PdfSizeTarget.Mb5,
+                    bitonalEligible = false,
+                )
+
+            assertEquals(listOf(1, 2), largeSamples)
+            assertEquals(listOf(1, 1), smallSamples)
+            assertEquals(2, result.sampleMultiplier)
+            assertTrue(result.targetMet)
+        }
+
+    @Test
+    fun failedProfilesAreDeletedBeforeTheNextProfileRenders() =
+        withTempDirectory { directory ->
+            val liveProfileCounts = mutableListOf<Int>()
+            val page =
+                fakePage(directory, "page", longestEdge = 6_000) { sample ->
+                    val buildDirectory =
+                        checkNotNull(
+                            directory.listFiles()?.singleOrNull {
+                                it.isDirectory && it.name.startsWith(".scanit-pdf-build-")
+                            },
+                        )
+                    liveProfileCounts +=
+                        buildDirectory.listFiles()!!.count {
+                            it.isDirectory && it.name.startsWith("profile-")
+                        }
+                    when (sample) {
+                        1 -> 8 * MB
+                        2 -> 7 * MB
+                        else -> 6 * MB
+                    }
+                }
+
+            val result =
+                buildScanPdf(
+                    File(directory, "smallest.pdf"),
+                    listOf(page),
+                    PdfSizeTarget.Mb5,
+                    bitonalEligible = false,
+                )
+
+            assertEquals(listOf(1, 1, 1), liveProfileCounts)
+            assertFalse(result.targetMet)
+            assertEquals(4, result.sampleMultiplier)
+        }
+
+    @Test
+    fun boundedTargetPublishesFirstMeasuredProfileThatFits() =
+        withTempDirectory { directory ->
+            val rendered = mutableListOf<Int>()
+            val page =
+                fakePage(directory, longestEdge = 5_000) { sample ->
+                    rendered += sample
+                    if (sample == 1) 6 * MIB else 2 * MIB
+                }
+            val output = File(directory, "scan.pdf")
+
+            val result = buildScanPdf(output, listOf(page), PdfSizeTarget.Mb5, false)
+
+            assertEquals(listOf(1, 2), rendered)
+            assertEquals(2, result.sampleMultiplier)
+            assertTrue(result.targetMet)
+            assertEquals(PdfEncoding.Jpeg, result.encoding)
+            assertEquals(output.length(), result.bytes)
+            assertTrue(output.isFile)
+            assertTrue(
+                output.readText(Charsets.ISO_8859_1).contains("/MediaBox [0 0 1200 480]"),
+            )
+        }
+
+    @Test
+    fun blackWhiteKeepsSmallerValidBitonalCandidate() =
+        withTempDirectory { directory ->
+            val output = File(directory, "scan.pdf")
+            val page = fakePage(directory, longestEdge = 1_280) { 64 * 1024 }
+
+            val result = buildScanPdf(output, listOf(page), PdfSizeTarget.Original, true)
+
+            assertEquals(PdfEncoding.Bitonal, result.encoding)
+            assertTrue(result.bytes < 64 * 1024)
+            assertTrue(output.readText(Charsets.ISO_8859_1).contains("/BitsPerComponent 1"))
+        }
+
+    @Test
+    fun impossibleTargetKeepsSmallestLegibleCandidateAndReportsActualSize() =
+        withTempDirectory { directory ->
+            val page =
+                fakePage(directory, longestEdge = 5_000) { sample ->
+                    when (sample) {
+                        1 -> 7 * MIB
+                        2 -> 6 * MIB
+                        else -> error("Unexpected sample")
+                    }
+                }
+            val output = File(directory, "scan.pdf")
+
+            val result = buildScanPdf(output, listOf(page), PdfSizeTarget.Mb5, false)
+
+            assertFalse(result.targetMet)
+            assertEquals(2, result.sampleMultiplier)
+            assertEquals(output.length(), result.bytes)
+            assertTrue(result.bytes > PdfSizeTarget.Mb5.maxBytes!!)
+        }
+
+    @Test
+    fun cancellationDoesNotPublishOrLeaveWorkingFiles() =
+        withTempDirectory { directory ->
+            val output = File(directory, "scan.pdf")
+            try {
+                buildScanPdf(
+                    output,
+                    listOf(fakePage(directory, longestEdge = 1_280) { 1 }),
+                    PdfSizeTarget.Original,
+                    false,
+                    isCancelled = { true },
+                )
+                fail("Expected cancellation")
+            } catch (_: CancellationException) {}
+
+            assertFalse(output.exists())
+            assertTrue(directory.listFiles()?.none { it.name.startsWith(".scanit-pdf-build-") } == true)
+        }
+
+    @Test
+    fun cancellationBetweenPageRendersStopsImmediatelyAndCleansWorkingFiles() =
+        withTempDirectory { directory ->
+            var rendered = 0
+            val pages =
+                List(3) { index ->
+                    fakePage(directory, "page-$index", longestEdge = 1_280) {
+                        rendered++
+                        1
+                    }
+                }
+            val output = File(directory, "scan.pdf")
+
+            assertThrows(CancellationException::class.java) {
+                buildScanPdf(
+                    output,
+                    pages,
+                    PdfSizeTarget.Original,
+                    bitonalEligible = false,
+                    isCancelled = { rendered >= 1 },
+                )
+            }
+
+            assertEquals(1, rendered)
+            assertFalse(output.exists())
+            assertTrue(directory.listFiles()?.none { it.name.startsWith(".scanit-pdf-build-") } == true)
+        }
+
+    private fun fakePage(
+        root: File,
+        pageName: String = "page",
+        longestEdge: Int,
+        jpegBytes: (sampleMultiplier: Int) -> Int,
+    ): ScanPdfBuildPage =
+        ScanPdfBuildPage(
+            longestEdge = longestEdge,
+            renderJpeg = { workingDirectory, sample ->
+                val file = File(workingDirectory, "$pageName-$sample.jpg")
+                file.outputStream().use { output ->
+                    val remaining = jpegBytes(sample)
+                    val block = ByteArray(minOf(remaining, 8_192)) { 0x41 }
+                    var written = 0
+                    while (written < remaining) {
+                        val count = minOf(block.size, remaining - written)
+                        output.write(block, 0, count)
+                        written += count
+                    }
+                }
+                JpegPdfPage(
+                    file,
+                    longestEdge / sample,
+                    minOf(2_000, longestEdge) / sample,
+                    physicalWidthPixels = longestEdge,
+                    physicalHeightPixels = minOf(2_000, longestEdge),
+                )
+            },
+            createBitonal = { jpeg ->
+                BitonalPdfPage(
+                    jpeg.width,
+                    jpeg.height,
+                    physicalWidthPixels = jpeg.physicalWidthPixels,
+                    physicalHeightPixels = jpeg.physicalHeightPixels,
+                ) { _, pixels -> pixels.fill(1) }
+            },
+        )
+
+    private inline fun withTempDirectory(block: (File) -> Unit) {
+        val directory = Files.createTempDirectory("scanit-pdf-builder-test-").toFile()
+        try {
+            block(directory)
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private companion object {
+        const val MB = 1_000_000
+        const val MIB = 1024 * 1024
+    }
+}

--- a/app/src/test/java/com/majkeylab/scanit/ScannerPageLimitTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/ScannerPageLimitTest.kt
@@ -1,0 +1,22 @@
+package com.majkeylab.scanit
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScannerPageLimitTest {
+    @Test
+    fun scannerAlwaysHasAnExplicitBoundedPageLimit() {
+        assertEquals(20, scannerPageLimit(multipage = true))
+        assertEquals(1, scannerPageLimit(multipage = false))
+    }
+
+    @Test
+    fun scanPageCountUsesTheSameBoundAtTheProcessingBoundary() {
+        assertFalse(isAcceptedScanPageCount(0))
+        assertTrue(isAcceptedScanPageCount(1))
+        assertTrue(isAcceptedScanPageCount(20))
+        assertFalse(isAcceptedScanPageCount(21))
+    }
+}


### PR DESCRIPTION
## Summary
- add per-filter intensity and shadows controls with B&W 100 / shadows 50 defaults
- add measured Original / 5 / 10 / 20 MB PDF output policies
- make appearance revisions crash-safe and generation-safe
- keep Settings open when persistence cannot be applied

## Verification
- 295 internal JVM tests, 0 failures/errors
- lintInternalDebug + assembleInternalDebug
- full 161-task signed internal/Play/GitHub gate
- all four release artifacts passed tools/verify-release.ps1

## Device QA
- exact internal APK installation started on SM-S938B; wireless ADB disconnected during Google photo-picker import and did not reappear via mDNS
- no stable package was installed or modified