### PR TITLE
fix: make initial scan publication crash-safe

### DIFF
--- a/app/src/main/java/com/majkeylab/scanit/OutputMetadata.kt
+++ b/app/src/main/java/com/majkeylab/scanit/OutputMetadata.kt
@@ -19,7 +19,8 @@ internal const val OUTPUT_METADATA_FILE_NAME = "outputs.json"
 internal const val OUTPUT_METADATA_TEMP_FILE_NAME = ".outputs.json.tmp"
 internal const val MAX_OUTPUT_METADATA_BYTES = 64 * 1024
 
-private const val OUTPUT_METADATA_VERSION = 1
+private const val OUTPUT_METADATA_VERSION = 2
+private const val OUTPUT_METADATA_LEGACY_VERSION = 1
 private const val MAX_CACHE_ID_LENGTH = 128
 private const val MAX_CONTENT_URI_LENGTH = 4096
 
@@ -31,6 +32,7 @@ internal data class PdfOutputRef(
     val ownerPackageName: String? = null,
     val byteLength: Long? = null,
     val sha256: String? = null,
+    val pending: Boolean = false,
 )
 
 internal data class ImageOutputRef(
@@ -41,6 +43,7 @@ internal data class ImageOutputRef(
     val ownerPackageName: String? = null,
     val byteLength: Long? = null,
     val sha256: String? = null,
+    val pending: Boolean = false,
 )
 
 internal data class OutputMetadata(
@@ -78,6 +81,7 @@ internal fun encodeOutputMetadata(metadata: OutputMetadata, pageCount: Int): Byt
         pdf.ownerPackageName?.let { value.put("ownerPackageName", it) }
         pdf.byteLength?.let { value.put("byteLength", it) }
         pdf.sha256?.let { value.put("sha256", it) }
+        if (pdf.pending) value.put("pending", true)
         json.put("pdf", value)
     }
     val images = JSONArray()
@@ -88,6 +92,7 @@ internal fun encodeOutputMetadata(metadata: OutputMetadata, pageCount: Int): Byt
         image.ownerPackageName?.let { value.put("ownerPackageName", it) }
         image.byteLength?.let { value.put("byteLength", it) }
         image.sha256?.let { value.put("sha256", it) }
+        if (image.pending) value.put("pending", true)
         images.put(value)
     }
     json.put("images", images)
@@ -107,9 +112,10 @@ internal fun decodeOutputMetadata(
     if (bytes.isEmpty() || bytes.size > MAX_OUTPUT_METADATA_BYTES) return null
     return try {
         val json = JSONObject(String(bytes, StandardCharsets.UTF_8))
+        val version = json.strictInt("version")
         if (
             !json.hasOnlyKeys(ROOT_KEYS, REQUIRED_ROOT_KEYS) ||
-                json.strictInt("version") != OUTPUT_METADATA_VERSION
+                version !in setOf(OUTPUT_METADATA_LEGACY_VERSION, OUTPUT_METADATA_VERSION)
         ) {
             return null
         }
@@ -117,6 +123,7 @@ internal fun decodeOutputMetadata(
             if (json.has("pdf")) {
                 val value = json.opt("pdf") as? JSONObject ?: return null
                 if (!value.hasOnlyKeys(PDF_KEYS, REQUIRED_PDF_KEYS)) return null
+                if (version == OUTPUT_METADATA_LEGACY_VERSION && value.has("pending")) return null
                 PdfOutputRef(
                     uri = value.strictString("uri") ?: return null,
                     treeUri = if (value.has("treeUri")) value.strictString("treeUri") ?: return null else null,
@@ -138,6 +145,8 @@ internal fun decodeOutputMetadata(
                         if (value.has("byteLength")) value.strictLong("byteLength") ?: return null else null,
                     sha256 =
                         if (value.has("sha256")) value.strictString("sha256") ?: return null else null,
+                    pending =
+                        if (value.has("pending")) value.strictBoolean("pending") ?: return null else false,
                 )
             } else {
                 null
@@ -148,6 +157,7 @@ internal fun decodeOutputMetadata(
                 repeat(imageValues.length()) { index ->
                     val value = imageValues.opt(index) as? JSONObject ?: return null
                     if (!value.hasOnlyKeys(IMAGE_KEYS, REQUIRED_IMAGE_KEYS)) return null
+                    if (version == OUTPUT_METADATA_LEGACY_VERSION && value.has("pending")) return null
                     add(
                         ImageOutputRef(
                             page = value.strictInt("page") ?: return null,
@@ -181,6 +191,12 @@ internal fun decodeOutputMetadata(
                                     value.strictString("sha256") ?: return null
                                 } else {
                                     null
+                                },
+                            pending =
+                                if (value.has("pending")) {
+                                    value.strictBoolean("pending") ?: return null
+                                } else {
+                                    false
                                 },
                         ),
                     )
@@ -397,6 +413,8 @@ private fun isValidOutputMetadata(
         metadata.pdf?.let { pdf ->
             !isContentUri(pdf.uri) ||
                 (pdf.treeUri != null && !isContentUri(pdf.treeUri)) ||
+                (pdf.pending && pdf.treeUri != null) ||
+                (pdf.pending && !pdf.hasPendingMediaIdentity(PDF_MIME_TYPE)) ||
                 !isValidOutputFingerprint(pdf.byteLength, pdf.sha256) ||
                 if (pdf.treeUri == null) {
                     !isValidMediaIdentity(
@@ -417,6 +435,7 @@ private fun isValidOutputMetadata(
     return metadata.images.all { image ->
         image.page in 1..pageCount &&
             isContentUri(image.uri) &&
+            (!image.pending || image.hasPendingMediaIdentity(JPEG_MIME_TYPE)) &&
             isValidOutputFingerprint(image.byteLength, image.sha256) &&
             isValidMediaIdentity(
                 image.displayName,
@@ -426,6 +445,18 @@ private fun isValidOutputMetadata(
             )
     }
 }
+
+private fun PdfOutputRef.hasPendingMediaIdentity(requiredMimeType: String): Boolean =
+    isProviderDisplayName(displayName) &&
+        mimeType == requiredMimeType &&
+        !ownerPackageName.isNullOrBlank() &&
+        outputFingerprint() != null
+
+private fun ImageOutputRef.hasPendingMediaIdentity(requiredMimeType: String): Boolean =
+    isProviderDisplayName(displayName) &&
+        mimeType == requiredMimeType &&
+        !ownerPackageName.isNullOrBlank() &&
+        outputFingerprint() != null
 
 internal fun isCanonicalUuid(value: String): Boolean =
     try {
@@ -501,10 +532,28 @@ private val ROOT_KEYS =
     )
 private val REQUIRED_ROOT_KEYS = ROOT_KEYS - setOf("pdf", "removeRecentPending")
 private val PDF_KEYS =
-    setOf("uri", "treeUri", "displayName", "mimeType", "ownerPackageName", "byteLength", "sha256")
+    setOf(
+        "uri",
+        "treeUri",
+        "displayName",
+        "mimeType",
+        "ownerPackageName",
+        "byteLength",
+        "sha256",
+        "pending",
+    )
 private val REQUIRED_PDF_KEYS = setOf("uri")
 private val IMAGE_KEYS =
-    setOf("page", "uri", "displayName", "mimeType", "ownerPackageName", "byteLength", "sha256")
+    setOf(
+        "page",
+        "uri",
+        "displayName",
+        "mimeType",
+        "ownerPackageName",
+        "byteLength",
+        "sha256",
+        "pending",
+    )
 private val REQUIRED_IMAGE_KEYS = setOf("page", "uri")
 private const val PDF_MIME_TYPE = "application/pdf"
 private const val JPEG_MIME_TYPE = "image/jpeg"

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -394,6 +394,7 @@ internal data class SavedMediaOutput(
     val ownerPackageName: String,
     val byteLength: Long,
     val sha256: String,
+    val pending: Boolean,
 )
 
 internal class PendingMediaFailure(

--- a/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
@@ -60,6 +60,7 @@ private val MEDIA_IDENTITY_PROJECTION =
         MediaStore.MediaColumns.DISPLAY_NAME,
         MediaStore.MediaColumns.MIME_TYPE,
         MediaStore.MediaColumns.OWNER_PACKAGE_NAME,
+        MediaStore.MediaColumns.IS_PENDING,
     )
 
 internal fun <T> pendingMediaWrite(
@@ -82,7 +83,8 @@ internal fun existingCompleteImagesForSave(
     when {
         pageCount <= 0 -> throw IOException("Scan has no pages")
         metadata.images.isEmpty() -> null
-        metadata.images.map(ImageOutputRef::page) == (1..pageCount).toList() -> metadata.images
+        metadata.images.map(ImageOutputRef::page) == (1..pageCount).toList() &&
+            metadata.images.none(ImageOutputRef::pending) -> metadata.images
         else -> throw IOException("Cached image output metadata is incomplete")
     }
 
@@ -182,6 +184,11 @@ private data class ParsedCacheEntry(
     val outputs: OutputMetadata?,
     val provisional: Boolean,
 )
+
+private fun ParsedCacheEntry.hasPendingMediaOwnership(): Boolean =
+    outputs?.let { metadata ->
+        metadata.pdf?.pending == true || metadata.images.any(ImageOutputRef::pending)
+    } == true
 
 internal fun nextDerivedCacheId(
     sourceCacheId: String,
@@ -471,12 +478,23 @@ private fun activateCheckpointProvisionalCacheEntryInRoot(
             candidateCacheId,
     ) ?: throw IOException("Checkpoint cache entry is unavailable")
     if (!candidate.provisional) return candidate.cached
-    val parentCacheId = candidate.cached.parentCacheId
-        ?: throw IOException("Provisional cache parent is unavailable")
-    val parentEntryId = candidate.cached.parentEntryId
-        ?: throw IOException("Provisional cache parent generation is unavailable")
     if (candidate.cached.appearanceSettings == null) {
         throw IOException("Provisional cache appearance authority is unavailable")
+    }
+    val parentCacheId = candidate.cached.parentCacheId
+    val parentEntryId = candidate.cached.parentEntryId
+    if (parentCacheId == null && parentEntryId == null) {
+        return activateProvisionalCacheEntryInRoot(
+            root = safeRoot,
+            candidateCacheId = candidateCacheId,
+            retireCacheId = null,
+            protectedCacheIds = emptySet(),
+            maxEntries = maxEntries,
+            moveEntry = moveEntry,
+        )
+    }
+    if (parentCacheId == null || parentEntryId == null) {
+        throw IOException("Provisional cache parent generation is incomplete")
     }
     val parent = readCacheEntries(safeRoot).singleOrNull {
         it.recent.cacheId == parentCacheId
@@ -527,7 +545,10 @@ private fun activationEntriesToRemove(
             entry
         }
     val remaining = entries.filterNot { it === retired }
-    val protectedEntries = remaining.filter { it.recent.cacheId in protectedCacheIds }
+    val protectedEntries =
+        remaining.filter { entry ->
+            entry.recent.cacheId in protectedCacheIds || entry.hasPendingMediaOwnership()
+        }
     if (protectedEntries.size > activeCapacity) {
         throw IOException("Protected recent scans exceed cache capacity")
     }
@@ -630,7 +651,10 @@ private fun entriesToPrune(
     maxEntries: Int,
 ): List<ParsedCacheEntry> {
     val entries = readCacheEntries(root)
-    val protectedEntries = entries.filter { it.recent.cacheId in protectedCacheIds }
+    val protectedEntries =
+        entries.filter { entry ->
+            entry.recent.cacheId in protectedCacheIds || entry.hasPendingMediaOwnership()
+        }
     if (protectedEntries.size > maxEntries) {
         throw IOException("Protected recent scans exceed cache capacity")
     }
@@ -776,10 +800,11 @@ private fun readCacheEntry(
             pdfBytes = exactPdf.length(),
             firstPage = orderedPages.first(),
             entryId = outputs?.entryId,
-            hasSavedPdf = outputs?.pdf?.outputFingerprint() != null,
+            hasSavedPdf = outputs?.pdf?.let { !it.pending && it.outputFingerprint() != null } == true,
             savedImageCount =
                 outputs?.images?.takeIf {
-                    it.isNotEmpty() && it.all { image -> image.outputFingerprint() != null }
+                    it.isNotEmpty() &&
+                        it.all { image -> !image.pending && image.outputFingerprint() != null }
                 }?.size ?: 0,
             removeRecentPending = outputs?.removeRecentPending == true,
         )
@@ -1272,7 +1297,7 @@ internal class ScanStorage(
                     createdAtEpochMs = clock.millis(),
                 )
                 CachedScanBuild(
-                    cached = recentScanCache.publish(workDirectory, finalDirectory),
+                    cached = recentScanCache.publishProvisional(workDirectory, finalDirectory),
                     pdf = pdfBuild,
                 )
             } catch (failure: Throwable) {
@@ -1384,6 +1409,13 @@ internal class ScanStorage(
     fun openSavedScan(cacheId: String): SavedScan? =
         storageTransactionLock.withLock {
             val cached = recentScanCache.open(cacheId) ?: return@withLock null
+            try {
+                reconcilePendingMediaOutputs(cached)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Exception) {
+                // Keep exact pending ownership for a later retry.
+            }
             val outputs =
                 cached.entryId?.let { entryId ->
                     readOutputMetadata(
@@ -1396,13 +1428,15 @@ internal class ScanStorage(
                 outputs?.takeIf { it.hasCompleteExactDeleteInventory(context.packageName) }
             SavedScan(
                 cached = cached,
-                galleryPages = outputs?.images?.map { it.uri.toUri() }.orEmpty(),
-                savedPdf = outputs?.pdf?.uri?.toUri(),
-                savedPdfTree = outputs?.pdf?.treeUri?.toUri(),
+                galleryPages = outputs?.images?.filterNot(ImageOutputRef::pending)?.map { it.uri.toUri() }.orEmpty(),
+                savedPdf = outputs?.pdf?.takeUnless(PdfOutputRef::pending)?.uri?.toUri(),
+                savedPdfTree = outputs?.pdf?.takeUnless(PdfOutputRef::pending)?.treeUri?.toUri(),
                 warnings = listOfNotNull(pdfSizeTargetWarning(cached.pdfSizeTarget, cached.pdf.length())),
                 outputMetadataValid = outputs != null,
-                savedPdfDeleteVerified = deleteMetadata?.pdf != null,
-                savedImagesDeleteVerified = deleteMetadata?.images?.isNotEmpty() == true,
+                savedPdfDeleteVerified =
+                    deleteMetadata?.pdf?.takeUnless(PdfOutputRef::pending) != null,
+                savedImagesDeleteVerified =
+                    deleteMetadata?.images?.any { !it.pending } == true,
             )
         }
 
@@ -1625,7 +1659,9 @@ internal class ScanStorage(
             require(cached.pages.isNotEmpty()) { "Scan has no pages" }
             val relativePath = "${Environment.DIRECTORY_PICTURES}/${normalizeAlbumName(album)}"
             val saved = mutableListOf<SavedMediaOutput>()
+            var metadataCommitted = false
             try {
+                reconcilePendingMediaOutputs(cached)
                 existingCompleteImagesForSave(
                     requireCurrentOutputMetadata(cached),
                     cached.pages.size,
@@ -1652,28 +1688,45 @@ internal class ScanStorage(
                 rewriteCachedOutputMetadata(cached) { metadata ->
                     metadata.copy(
                         images =
-                            saved.mapIndexed { index, uri ->
+                            saved.mapIndexed { index, output ->
                                 ImageOutputRef(
                                     page = index + 1,
-                                    uri = uri.uri.toString(),
-                                    displayName = uri.displayName,
-                                    mimeType = uri.mimeType,
-                                    ownerPackageName = uri.ownerPackageName,
-                                    byteLength = uri.byteLength,
-                                    sha256 = uri.sha256,
+                                    uri = output.uri.toString(),
+                                    displayName = output.displayName,
+                                    mimeType = output.mimeType,
+                                    ownerPackageName = output.ownerPackageName,
+                                    byteLength = output.byteLength,
+                                    sha256 = output.sha256,
+                                    pending = true,
                                 )
                             },
                     )
                 }
-                saved.map(SavedMediaOutput::uri)
+                metadataCommitted = true
+                val published =
+                    saved.map {
+                        publishPendingFile(it, MediaOutputCollection.Images)
+                    }
+                rewriteCachedOutputMetadata(cached) { metadata ->
+                    metadata.copy(
+                        images = metadata.images.map { it.copy(pending = false) },
+                    )
+                }
+                published.map(SavedMediaOutput::uri)
             } catch (cancellation: CancellationException) {
-                saved.forEach { rollbackMediaOutput(it, MediaOutputCollection.Images, cancellation) }
+                if (!metadataCommitted) {
+                    saved.forEach {
+                        rollbackMediaOutput(it, MediaOutputCollection.Images, cancellation)
+                    }
+                }
                 throw cancellation
             } catch (exception: Exception) {
                 var rollbackFailed = false
-                saved.forEach { output ->
-                    if (!rollbackMediaOutput(output, MediaOutputCollection.Images, exception)) {
-                        rollbackFailed = true
+                if (!metadataCommitted) {
+                    saved.forEach { output ->
+                        if (!rollbackMediaOutput(output, MediaOutputCollection.Images, exception)) {
+                            rollbackFailed = true
+                        }
                     }
                 }
                 throw ImageSaveFailure(exception, rollbackFailed)
@@ -1690,8 +1743,14 @@ internal class ScanStorage(
             val displayName = scanPdfFileName(cached.baseName)
             var failureWarning: UiMessage? = null
             var createdOutput: SavedPdfOutput? = null
+            var pendingMedia: SavedMediaOutput? = null
+            var metadataCommitted = false
             try {
+                reconcilePendingMediaOutputs(cached)
                 requireCurrentOutputMetadata(cached).pdf?.let { existing ->
+                    if (existing.pending) {
+                        throw IOException("Saved PDF publication is still pending")
+                    }
                     return@withLock SavedPdfOutput(
                         uri = existing.uri.toUri(),
                         treeUri = existing.treeUri?.toUri(),
@@ -1712,12 +1771,16 @@ internal class ScanStorage(
                         } else {
                             failureWarning =
                                 safFallbackWarning(cleanupFailed, savedToDownloads = false)
-                            savePdfToDownloads(cached.pdf, displayName, album).toPdfOutput(
-                                safFallbackWarning(cleanupFailed, savedToDownloads = true),
-                            )
+                            savePdfToDownloads(cached.pdf, displayName, album)
+                                .also { pendingMedia = it }
+                                .toPdfOutput(
+                                    safFallbackWarning(cleanupFailed, savedToDownloads = true),
+                                )
                         }
                     } else {
-                        savePdfToDownloads(cached.pdf, displayName, album).toPdfOutput()
+                        savePdfToDownloads(cached.pdf, displayName, album)
+                            .also { pendingMedia = it }
+                            .toPdfOutput()
                     }
                 createdOutput = output
                 rewriteCachedOutputMetadata(cached) { metadata ->
@@ -1731,16 +1794,36 @@ internal class ScanStorage(
                                 ownerPackageName = output.ownerPackageName,
                                 byteLength = output.byteLength,
                                 sha256 = output.sha256,
+                                pending = pendingMedia != null,
                             ),
                     )
                 }
-                output
+                metadataCommitted = true
+                val media = pendingMedia
+                if (media == null) {
+                    output
+                } else {
+                    val published =
+                        publishPendingFile(media, MediaOutputCollection.Downloads)
+                            .toPdfOutput(output.warning)
+                    createdOutput = published
+                    rewriteCachedOutputMetadata(cached) { metadata ->
+                        metadata.copy(pdf = metadata.pdf?.copy(pending = false))
+                    }
+                    published
+                }
             } catch (cancellation: CancellationException) {
-                createdOutput?.let { rollbackPdfOutput(it, cancellation) }
+                if (!metadataCommitted) {
+                    createdOutput?.let { rollbackPdfOutput(it, cancellation) }
+                }
                 throw cancellation
             } catch (exception: Exception) {
                 val rollbackFailed =
-                    createdOutput?.let { !rollbackPdfOutput(it, exception) } ?: false
+                    if (metadataCommitted) {
+                        false
+                    } else {
+                        createdOutput?.let { !rollbackPdfOutput(it, exception) } ?: false
+                    }
                 throw PdfSaveFailure(failureWarning, exception, rollbackFailed)
             }
         }
@@ -1783,6 +1866,112 @@ internal class ScanStorage(
             pageCount = cached.pages.size,
             update = update,
         )
+    }
+
+    private fun reconcilePendingMediaOutputs(cached: CachedScan) {
+        val current = requireCurrentOutputMetadata(cached)
+        var pdf = current.pdf
+        var images = current.images
+        var changed = false
+        val pendingPdf = pdf?.takeIf(PdfOutputRef::pending)
+        if (pendingPdf != null) {
+            val completed =
+                try {
+                    reconcilePendingMediaOutput(
+                        uri = pendingPdf.uri,
+                        displayName = pendingPdf.displayName,
+                        mimeType = pendingPdf.mimeType,
+                        ownerPackageName = pendingPdf.ownerPackageName,
+                        fingerprint = pendingPdf.outputFingerprint(),
+                        source = cached.pdf,
+                        collection = MediaOutputCollection.Downloads,
+                    )
+                } catch (_: NoSuchFileException) {
+                    pdf = null
+                    changed = true
+                    null
+                }
+            if (completed != null) {
+                pdf =
+                    pendingPdf.copy(
+                        displayName = completed.displayName,
+                        mimeType = completed.mimeType,
+                        ownerPackageName = completed.ownerPackageName,
+                        byteLength = completed.byteLength,
+                        sha256 = completed.sha256,
+                        pending = false,
+                    )
+                changed = true
+            }
+        }
+        images =
+            images.mapNotNull { image ->
+                if (!image.pending) return@mapNotNull image
+                val page = cached.pages.getOrNull(image.page - 1) ?: return@mapNotNull image
+                try {
+                    val completed =
+                        reconcilePendingMediaOutput(
+                            uri = image.uri,
+                            displayName = image.displayName,
+                            mimeType = image.mimeType,
+                            ownerPackageName = image.ownerPackageName,
+                            fingerprint = image.outputFingerprint(),
+                            source = page,
+                            collection = MediaOutputCollection.Images,
+                        ) ?: return@mapNotNull image
+                    changed = true
+                    image.copy(
+                        displayName = completed.displayName,
+                        mimeType = completed.mimeType,
+                        ownerPackageName = completed.ownerPackageName,
+                        byteLength = completed.byteLength,
+                        sha256 = completed.sha256,
+                        pending = false,
+                    )
+                } catch (_: NoSuchFileException) {
+                    changed = true
+                    null
+                }
+            }
+        if (changed) {
+            rewriteCachedOutputMetadata(cached) { metadata ->
+                metadata.copy(pdf = pdf, images = images)
+            }
+        }
+    }
+
+    private fun reconcilePendingMediaOutput(
+        uri: String,
+        displayName: String?,
+        mimeType: String?,
+        ownerPackageName: String?,
+        fingerprint: OutputFingerprint?,
+        source: File,
+        collection: MediaOutputCollection,
+    ): SavedMediaOutput? {
+        val expected = fingerprint ?: return null
+        if (
+            !isProviderDisplayName(displayName) ||
+                mimeType == null ||
+                ownerPackageName != context.packageName ||
+                fingerprintFile(source) != expected
+        ) {
+            return null
+        }
+        val observed =
+            readSavedMediaOutput(
+                uri.toUri(),
+                collection,
+                mimeType,
+                expected,
+            )
+        if (
+            observed.displayName != displayName ||
+                observed.ownerPackageName != ownerPackageName
+        ) {
+            return null
+        }
+        return publishPendingFile(observed, collection).takeUnless(SavedMediaOutput::pending)
     }
 
     private fun requireCurrentOutputMetadata(cached: CachedScan): OutputMetadata {
@@ -2020,34 +2209,76 @@ internal class ScanStorage(
                     expectedMimeType,
                     sourceFingerprint,
                 )
-            verifiedOutput = pendingOutput
-            val address = parseMediaItemAddress(destination.toString())
-                ?: throw IOException("MediaStore item URI is invalid")
-            val published =
-                resolver.update(
-                    destination,
-                    ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
-                    MEDIA_PUBLISH_SELECTION,
-                    mediaDeleteSelectionArgs(
-                        ExpectedMediaItem(
-                            id = address.id,
-                            displayName = pendingOutput.displayName,
-                            mimeType = pendingOutput.mimeType,
-                            ownerPackageName = pendingOutput.ownerPackageName,
-                        ),
-                    ),
-                )
-            if (published != 1) {
-                throw IOException("MediaStore row could not be published")
+            if (!pendingOutput.pending) {
+                throw IOException("MediaStore row was published before ownership was recorded")
             }
-            readSavedMediaOutput(
-                destination,
-                expectedCollection,
-                expectedMimeType,
-                sourceFingerprint,
-            )
+            verifiedOutput = pendingOutput
+            pendingOutput
         }
     }
+
+    private fun publishPendingFile(
+        output: SavedMediaOutput,
+        expectedCollection: MediaOutputCollection,
+    ): SavedMediaOutput {
+        val fingerprint = OutputFingerprint(output.byteLength, output.sha256)
+        val current =
+            readSavedMediaOutput(
+                output.uri,
+                expectedCollection,
+                output.mimeType,
+                fingerprint,
+            )
+        if (!sameMediaOutput(current, output)) {
+            throw IOException("MediaStore item identity changed before publication")
+        }
+        if (!current.pending) return current
+        val address = parseMediaItemAddress(output.uri.toString())
+            ?: throw IOException("MediaStore item URI is invalid")
+        val published =
+            resolver.update(
+                output.uri,
+                ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
+                MEDIA_PUBLISH_SELECTION,
+                mediaDeleteSelectionArgs(
+                    ExpectedMediaItem(
+                        id = address.id,
+                        displayName = output.displayName,
+                        mimeType = output.mimeType,
+                        ownerPackageName = output.ownerPackageName,
+                    ),
+                ),
+            )
+        if (published != 1) {
+            val observed =
+                readSavedMediaOutput(
+                    output.uri,
+                    expectedCollection,
+                    output.mimeType,
+                    fingerprint,
+                )
+            if (!observed.pending && sameMediaOutput(observed, output)) return observed
+            throw IOException("MediaStore row could not be published")
+        }
+        return readSavedMediaOutput(
+            output.uri,
+            expectedCollection,
+            output.mimeType,
+            fingerprint,
+        ).also {
+            if (it.pending || !sameMediaOutput(it, output)) {
+                throw IOException("Published MediaStore row identity changed")
+            }
+        }
+    }
+
+    private fun sameMediaOutput(left: SavedMediaOutput, right: SavedMediaOutput): Boolean =
+        left.uri == right.uri &&
+            left.displayName == right.displayName &&
+            left.mimeType == right.mimeType &&
+            left.ownerPackageName == right.ownerPackageName &&
+            left.byteLength == right.byteLength &&
+            left.sha256 == right.sha256
 
     private fun readSavedMediaOutput(
         uri: Uri,
@@ -2072,16 +2303,18 @@ internal class ScanStorage(
             resolver.query(uri, MEDIA_IDENTITY_PROJECTION, null, null, null)
                 ?: throw IOException("MediaStore item identity is unavailable")
         return cursor.use {
-            if (!it.moveToFirst()) throw IOException("MediaStore item is unavailable")
+            if (!it.moveToFirst()) throw NoSuchFileException("MediaStore item is unavailable")
             val idIndex = it.getColumnIndex(MediaStore.MediaColumns._ID)
             val nameIndex = it.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME)
             val mimeIndex = it.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)
             val ownerIndex = it.getColumnIndex(MediaStore.MediaColumns.OWNER_PACKAGE_NAME)
+            val pendingIndex = it.getColumnIndex(MediaStore.MediaColumns.IS_PENDING)
             if (
                 idIndex < 0 ||
                     nameIndex < 0 ||
                     mimeIndex < 0 ||
                     ownerIndex < 0 ||
+                    pendingIndex < 0 ||
                     it.isNull(idIndex) ||
                     it.isNull(nameIndex) ||
                     it.isNull(mimeIndex)
@@ -2092,11 +2325,14 @@ internal class ScanStorage(
             val mimeType = it.getString(mimeIndex)
             val ownerPackageName =
                 if (it.isNull(ownerIndex)) null else it.getString(ownerIndex)
+            val pendingValue =
+                if (it.isNull(pendingIndex)) -1 else it.getInt(pendingIndex)
             if (
                 it.getLong(idIndex) != address.id ||
                     !isProviderDisplayName(displayName) ||
                     mimeType != expectedMimeType ||
                     ownerPackageName != context.packageName ||
+                    pendingValue !in 0..1 ||
                     it.moveToNext()
             ) {
                 throw IOException("MediaStore item identity changed")
@@ -2112,6 +2348,7 @@ internal class ScanStorage(
                 context.packageName,
                 fingerprint.byteLength,
                 fingerprint.sha256,
+                pending = pendingValue == 1,
             )
         }
     }

--- a/app/src/main/java/com/majkeylab/scanit/ScanViewModel.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanViewModel.kt
@@ -252,6 +252,12 @@ private data class OutputSaveResult(
     val warnings: List<UiMessage>,
 )
 
+private data class PreparedInitialScan(
+    val settings: AppSettings,
+    val build: CachedScanBuild,
+    val thumbnail: Bitmap?,
+)
+
 internal fun automaticOutputTarget(settings: AppSettings): SaveNowTarget? =
     when {
         settings.savePdf && settings.saveImages -> SaveNowTarget.Both
@@ -259,6 +265,8 @@ internal fun automaticOutputTarget(settings: AppSettings): SaveNowTarget? =
         settings.saveImages -> SaveNowTarget.Images
         else -> null
     }
+
+internal fun automaticPdfUsesDownloads(pdfTreeUri: String?): Boolean = pdfTreeUri == null
 
 private enum class ResultActivation {
     Applied,
@@ -549,12 +557,10 @@ internal class ScanViewModel(
         processingJob =
             viewModelScope.launch {
                 var cached: CachedScan? = null
-                var galleryPages: List<Uri> = emptyList()
-                var savedPdfUri: Uri? = null
-                var savedPdfTreeUri: Uri? = null
-                var completedResult: ScreenState.Result? = null
+                var authorityCommitted = false
+                var retainedResult: ScreenState.Result? = null
                 try {
-                    val result =
+                    val prepared =
                         withContext(Dispatchers.IO) {
                             val settings = currentSettings()
                             val processingContext = currentCoroutineContext()
@@ -567,71 +573,39 @@ internal class ScanViewModel(
                                 )
                             val cachedScan = cacheBuild.cached
                             cached = cachedScan
-                            val thumbnail =
-                                storage.loadThumbnail(
-                                    cachedScan.pages.first(),
-                                    RESULT_PREVIEW_SIZE,
-                                )
-                            val warnings = mutableListOf<UiMessage>()
-                            if (!cacheBuild.pdf.targetMet) {
-                                warnings += pdfSizeTargetWarning(cacheBuild.pdf)
-                            }
-                            if (settings.saveImages) {
-                                try {
-                                    galleryPages =
-                                        storage.saveImages(cachedScan, settings.albumName)
-                                } catch (cancellation: CancellationException) {
-                                    throw cancellation
-                                } catch (failure: ImageSaveFailure) {
-                                    warnings += imageSaveFailureMessages(failure)
-                                } catch (_: Exception) {
-                                    warnings += UiMessage(R.string.images_save_failed)
-                                }
-                            }
                             currentCoroutineContext().ensureActive()
-                            if (settings.savePdf) {
-                                try {
-                                    val savedPdf =
-                                        savePdfToCanonicalDestination(
-                                            cachedScan,
-                                            settings.albumName,
-                                        )
-                                    savedPdfUri = savedPdf.uri
-                                    savedPdfTreeUri = savedPdf.treeUri
-                                    savedPdf.warning?.let(warnings::add)
-                                } catch (cancellation: CancellationException) {
-                                    throw cancellation
-                                } catch (failure: PdfSaveFailure) {
-                                    warnings += pdfSaveFailureMessages(failure)
-                                } catch (_: Exception) {
-                                    warnings += UiMessage(R.string.pdf_save_failed)
-                                }
-                            }
-                            val result =
-                                ScreenState.Result(
-                                    scan =
-                                        SavedScan(
-                                            cached = cachedScan,
-                                            galleryPages = galleryPages,
-                                            savedPdf = savedPdfUri,
-                                            savedPdfTree = savedPdfTreeUri,
-                                            warnings = warnings,
-                                            outputMetadataValid = true,
-                                            savedPdfDeleteVerified = savedPdfUri != null,
-                                            savedImagesDeleteVerified = galleryPages.isNotEmpty(),
-                                        ),
-                                    thumbnail = thumbnail,
-                                )
-                            completedResult = result
-                            currentCoroutineContext().ensureActive()
-                            result
+                            PreparedInitialScan(
+                                settings = settings,
+                                build = cacheBuild,
+                                thumbnail =
+                                    storage.loadThumbnail(
+                                        cachedScan.pages.first(),
+                                        RESULT_PREVIEW_SIZE,
+                                    ),
+                            )
                         }
-                    when (
-                        activateCachedResult(generation, result.scan.cached.baseName, result)
-                    ) {
-                        ResultActivation.Applied -> Unit
+                    val baseWarnings =
+                        if (prepared.build.pdf.targetMet) {
+                            emptyList()
+                        } else {
+                            listOf(pdfSizeTargetWarning(prepared.build.pdf))
+                        }
+                    retainedResult =
+                        ScreenState.Result(
+                            scan =
+                                SavedScan(
+                                    cached = prepared.build.cached,
+                                    galleryPages = emptyList(),
+                                    savedPdf = null,
+                                    warnings = baseWarnings,
+                                    outputMetadataValid = false,
+                                ),
+                            thumbnail = prepared.thumbnail,
+                        )
+                    when (persistResultCheckpoint(generation, prepared.build.cached.baseName)) {
+                        ResultActivation.Applied -> authorityCommitted = true
                         ResultActivation.Rejected -> {
-                            val cleanupComplete = cleanup(cached, galleryPages, savedPdfUri)
+                            val cleanupComplete = deleteUncommittedCandidate(prepared.build.cached)
                             if (routeMutationGate.isCurrent(generation)) {
                                 mutableState.value =
                                     ScreenState.Failure(
@@ -645,50 +619,85 @@ internal class ScanViewModel(
                                     )
                                 persistRoute(ROUTE_FAILURE)
                             }
+                            return@launch
                         }
-                        ResultActivation.Stale -> cleanup(cached, galleryPages, savedPdfUri)
+                        ResultActivation.Stale -> {
+                            discardAppearanceVariantUnlessActive(prepared.build.cached)
+                            return@launch
+                        }
                     }
-                } catch (exception: CancellationException) {
-                    val retainedResult = completedResult
-                    when (
-                        withContext(NonCancellable) {
-                            clearCheckpointAndPublish(
-                                generation = generation,
-                                onFailure = { retainedResult?.let(::publishResult) },
-                                onSuccess = {},
+                    if (!routeMutationGate.isCurrent(generation)) return@launch
+                    val result =
+                        withContext(Dispatchers.IO) {
+                            val activated =
+                                storage.activateCheckpointProvisional(prepared.build.cached)
+                            val warnings =
+                                (baseWarnings +
+                                    saveAutomaticInitialOutputs(
+                                        activated,
+                                        prepared.settings,
+                                    )).toMutableList()
+                            val saved =
+                                storage.openSavedScan(activated.baseName)
+                                    ?: throw IOException(
+                                        "Cached scan output metadata is unavailable",
+                                    )
+                            ScreenState.Result(
+                                scan =
+                                    saved.copy(
+                                        warnings = (warnings + saved.warnings).distinct(),
+                                    ),
+                                thumbnail = prepared.thumbnail,
                             )
                         }
-                    ) {
-                        CheckpointMutationResult.Failed -> {
-                            if (retainedResult == null) {
-                                cleanup(cached, galleryPages, savedPdfUri)
-                            }
+                    retainedResult = result
+                    routeMutationMutex.withLock {
+                        if (routeMutationGate.isCurrent(generation)) publishResult(result)
+                    }
+                } catch (exception: CancellationException) {
+                    if (!authorityCommitted) {
+                        cached?.let { candidate ->
+                            deleteUncommittedCandidate(candidate)
                         }
-                        CheckpointMutationResult.Applied,
-                        CheckpointMutationResult.Stale,
-                        -> cleanup(cached, galleryPages, savedPdfUri)
                     }
                     throw exception
-                } catch (exception: Exception) {
-                    val retainedResult = completedResult
-                    val checkpoint =
-                        clearCheckpointAndPublish(
-                            generation = generation,
-                            onFailure = { retainedResult?.let(::publishResult) },
-                            onSuccess = {},
-                        )
-                    val retained =
-                        checkpoint == CheckpointMutationResult.Failed && retainedResult != null
-                    if (!retained && routeMutationGate.isCurrent(generation)) {
-                        val cleanupComplete = cleanup(cached, galleryPages, savedPdfUri)
-                        val message =
-                            if (cleanupComplete && exception.suppressed.isEmpty()) {
-                                UiMessage(R.string.document_save_failed)
-                            } else {
-                                UiMessage(R.string.document_save_partial_failed)
+                } catch (_: Exception) {
+                    if (authorityCommitted) {
+                        retainedResult?.let { result ->
+                            routeMutationMutex.withLock {
+                                if (routeMutationGate.isCurrent(generation)) {
+                                    publishResult(
+                                        result.copy(
+                                            scan =
+                                                result.scan.copy(
+                                                    warnings =
+                                                        (result.scan.warnings +
+                                                            UiMessage(R.string.state_update_failed))
+                                                            .distinct(),
+                                                ),
+                                        ),
+                                    )
+                                }
                             }
-                        mutableState.value = ScreenState.Failure(message)
-                        persistRoute(ROUTE_FAILURE)
+                        }
+                    } else {
+                        val cleanupComplete =
+                            cached?.let { candidate ->
+                                deleteUncommittedCandidate(candidate)
+                            } ?: true
+                        if (routeMutationGate.isCurrent(generation)) {
+                            mutableState.value =
+                                ScreenState.Failure(
+                                    UiMessage(
+                                        if (cleanupComplete) {
+                                            R.string.document_save_failed
+                                        } else {
+                                            R.string.document_save_partial_failed
+                                        },
+                                    ),
+                                )
+                            persistRoute(ROUTE_FAILURE)
+                        }
                     }
                 } finally {
                     processingJob = null
@@ -1281,11 +1290,24 @@ internal class ScanViewModel(
         generation: Long,
         cacheId: String,
         result: ScreenState.Result,
+    ): ResultActivation {
+        val activation = persistResultCheckpoint(generation, cacheId)
+        if (activation == ResultActivation.Applied) {
+            routeMutationMutex.withLock {
+                if (routeMutationGate.isCurrent(generation)) publishResult(result)
+            }
+        }
+        return activation
+    }
+
+    private suspend fun persistResultCheckpoint(
+        generation: Long,
+        cacheId: String,
     ): ResultActivation =
         routeMutationMutex.withLock {
             if (!routeMutationGate.isCurrent(generation)) return@withLock ResultActivation.Stale
+            val owner = activeResultOwner ?: return@withLock ResultActivation.Stale
             try {
-                val owner = activeResultOwner ?: return@withLock ResultActivation.Stale
                 val saved =
                     withContext(Dispatchers.IO) {
                         settingsStore.saveActiveResult(cacheId, owner)
@@ -1297,41 +1319,31 @@ internal class ScanViewModel(
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (_: IOException) {
-                return@withLock recoverFailedResultCheckpoint(generation, result)
+                return@withLock recoverResultCheckpoint(cacheId, owner)
             } catch (_: IllegalArgumentException) {
-                return@withLock recoverFailedResultCheckpoint(generation, result)
+                return@withLock recoverResultCheckpoint(cacheId, owner)
             }
-            if (!routeMutationGate.isCurrent(generation)) return@withLock ResultActivation.Stale
-            publishResult(result)
             ResultActivation.Applied
         }
 
-    private suspend fun recoverFailedResultCheckpoint(
-        generation: Long,
-        result: ScreenState.Result,
-    ): ResultActivation {
-        val cleared =
-            try {
-                val owner = activeResultOwner ?: return ResultActivation.Stale
-                val result =
-                    withContext(Dispatchers.IO) {
-                        settingsStore.clearActiveResult(owner)
-                    }
-                if (result == AuthorityMutationResult.Applied) {
-                    activeResultOwner = owner.withCheckpoint(null)
+    private suspend fun recoverResultCheckpoint(
+        cacheId: String,
+        previousOwner: ActiveResultOwner,
+    ): ResultActivation =
+        try {
+            val snapshot =
+                withContext(Dispatchers.IO) {
+                    settingsStore.authoritySnapshot()
                 }
-                result == AuthorityMutationResult.Applied
-            } catch (_: IOException) {
-                false
+            activeResultOwner = snapshot.owner
+            when (snapshot.checkpoint) {
+                ActiveResultCheckpoint(cacheId) -> ResultActivation.Applied
+                previousOwner.checkpoint -> ResultActivation.Rejected
+                else -> ResultActivation.Stale
             }
-        if (!routeMutationGate.isCurrent(generation)) return ResultActivation.Stale
-        return if (cleared) {
-            ResultActivation.Rejected
-        } else {
-            publishResult(result)
-            ResultActivation.Applied
+        } catch (_: IOException) {
+            ResultActivation.Stale
         }
-    }
 
     private fun publishResult(result: ScreenState.Result) {
         val cacheId = result.scan.cached.baseName
@@ -1434,6 +1446,19 @@ internal class ScanViewModel(
             }
         }
     }
+
+    private suspend fun deleteUncommittedCandidate(candidate: CachedScan): Boolean =
+        withContext(NonCancellable + Dispatchers.IO) {
+            try {
+                storage.deleteProvisionalCacheEntry(candidate)
+            } catch (_: IOException) {
+                false
+            } catch (_: SecurityException) {
+                false
+            } catch (_: IllegalArgumentException) {
+                false
+            }
+        }
 
     private fun commitAppliedAppearance(
         normalized: ScanAppearanceSettings,
@@ -1539,7 +1564,48 @@ internal class ScanViewModel(
         val saved =
             storage.openSavedScan(activated.baseName)
                 ?: throw IOException("Cached scan output metadata is unavailable")
-        return saved.copy(warnings = (initialWarnings + saved.warnings).distinct())
+        return saved.copy(
+            warnings = (initialWarnings + saved.warnings).distinct(),
+        )
+    }
+
+    private suspend fun saveAutomaticInitialOutputs(
+        cached: CachedScan,
+        settings: AppSettings,
+    ): List<UiMessage> {
+        val warnings = mutableListOf<UiMessage>()
+        if (settings.saveImages) {
+            try {
+                storage.saveImages(cached, settings.albumName)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (failure: ImageSaveFailure) {
+                warnings += imageSaveFailureMessages(failure)
+            } catch (_: Exception) {
+                warnings += UiMessage(R.string.images_save_failed)
+            }
+        }
+        currentCoroutineContext().ensureActive()
+        if (settings.savePdf) {
+            if (automaticPdfUsesDownloads(settings.pdfTreeUri)) {
+                try {
+                    storage.savePdf(
+                        cached,
+                        settings.albumName,
+                        pdfTreeUri = null,
+                    ).warning?.let(warnings::add)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (failure: PdfSaveFailure) {
+                    warnings += pdfSaveFailureMessages(failure)
+                } catch (_: Exception) {
+                    warnings += UiMessage(R.string.pdf_save_failed)
+                }
+            } else {
+                warnings += UiMessage(R.string.pdf_auto_save_deferred)
+            }
+        }
+        return warnings.distinct()
     }
 
     private suspend fun readActiveResultCheckpoint(generation: Long): CheckpointReadResult =
@@ -1559,8 +1625,8 @@ internal class ScanViewModel(
                             if (
                                 provisional &&
                                     (authoritative.appearanceSettings == null ||
-                                        authoritative.parentCacheId == null ||
-                                        authoritative.parentEntryId == null)
+                                        (authoritative.parentCacheId == null) !=
+                                        (authoritative.parentEntryId == null))
                             ) {
                                 throw IOException(
                                     "Provisional checkpoint metadata is not authoritative",
@@ -1749,25 +1815,4 @@ internal class ScanViewModel(
         return tryStorageTransaction(operation)
             ?: throw IOException("PDF destination cleanup is still in progress")
     }
-
-    private suspend fun cleanup(
-        cached: CachedScan?,
-        galleryPages: List<Uri>,
-        savedPdf: Uri?,
-    ): Boolean =
-        withContext(NonCancellable + Dispatchers.IO) {
-            if (cached == null) return@withContext true
-            val target =
-                when {
-                    savedPdf != null && galleryPages.isNotEmpty() -> RecentDeleteTarget.Both
-                    savedPdf != null -> RecentDeleteTarget.Pdf
-                    galleryPages.isNotEmpty() -> RecentDeleteTarget.Images
-                    else -> null
-                }
-            if (target == null) return@withContext storage.deleteCachedScan(cached)
-            storage.deleteDurableOutputs(
-                OutputDeleteRequest(cached.baseName, cached.entryId, target),
-                deleteRecentCache = true,
-            ) == OutputDeleteOperationResult.Completed
-        }
 }

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -122,6 +122,7 @@
     <string name="saving_document">Dokument se ukládá…</string>
     <string name="images_save_failed">Obrázky se nepodařilo uložit do Galerie. Dokument lze stále odeslat.</string>
     <string name="pdf_save_failed">PDF se nepodařilo uložit. Dokument lze stále odeslat.</string>
+    <string name="pdf_auto_save_deferred">Vybranou složku je třeba potvrdit. PDF uložte v Podrobnostech souborů.</string>
     <string name="pdf_size_target_not_met">PDF se nepodařilo zmenšit pod %1$d MB bez příliš malých stránek. Skutečná velikost: %2$.2f MB.</string>
     <string name="document_save_failed">Dokument se nepodařilo uložit. Zkuste to znovu.</string>
     <string name="document_save_partial_failed">Dokument se nepodařilo uložit. Některé soubory mohly zůstat uložené.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="saving_document">Saving document…</string>
     <string name="images_save_failed">Images could not be saved to Gallery. The document can still be shared.</string>
     <string name="pdf_save_failed">The PDF could not be saved. The document can still be shared.</string>
+    <string name="pdf_auto_save_deferred">The selected folder needs confirmation. Use File details to save the PDF.</string>
     <string name="pdf_size_target_not_met">The PDF could not fit under %1$d MB without making pages too small. Actual size: %2$.2f MB.</string>
     <string name="document_save_failed">Could not save the document. Try again.</string>
     <string name="document_save_partial_failed">Could not save the document. Some files may remain saved.</string>

--- a/app/src/test/java/com/majkeylab/scanit/OutputMetadataTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/OutputMetadataTest.kt
@@ -135,6 +135,93 @@ class OutputMetadataTest {
     }
 
     @Test
+    fun pendingMediaOwnershipRoundTripsAndLegacyRowsDefaultToPublished() {
+        val pending =
+            OutputMetadata(
+                entryId = entryId,
+                cacheId = cacheId,
+                createdAtEpochMs = 1L,
+                pdf =
+                    PdfOutputRef(
+                        uri = "content://media/external/downloads/42",
+                        treeUri = null,
+                        displayName = "scan.pdf",
+                        mimeType = "application/pdf",
+                        ownerPackageName = "com.majkeylab.scanit.internal",
+                        byteLength = 10L,
+                        sha256 = "00".repeat(32),
+                        pending = true,
+                    ),
+                images =
+                    listOf(
+                        ImageOutputRef(
+                            page = 1,
+                            uri = "content://media/external/images/media/43",
+                            displayName = "scan.jpg",
+                            mimeType = "image/jpeg",
+                            ownerPackageName = "com.majkeylab.scanit.internal",
+                            byteLength = 11L,
+                            sha256 = "11".repeat(32),
+                            pending = true,
+                        ),
+                    ),
+            )
+
+        assertEquals(
+            pending,
+            decodeOutputMetadata(encodeOutputMetadata(pending, 1), cacheId, 1),
+        )
+
+        val legacy =
+            validJson(
+                images = """[{"page":1,"uri":"content://media/external/images/media/43"}]""",
+            ).toByteArray(StandardCharsets.UTF_8)
+        assertEquals(false, decodeOutputMetadata(legacy, cacheId, 1)?.images?.single()?.pending)
+    }
+
+    @Test
+    fun pendingMediaWithoutExactIdentityIsRejected() {
+        val incomplete =
+            OutputMetadata(
+                entryId = entryId,
+                cacheId = cacheId,
+                createdAtEpochMs = 1L,
+                pdf =
+                    PdfOutputRef(
+                        uri = "content://media/external/downloads/42",
+                        treeUri = null,
+                        pending = true,
+                    ),
+            )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            encodeOutputMetadata(incomplete, pageCount = 1)
+        }
+    }
+
+    @Test
+    fun pendingImagesAreNotTreatedAsCompletedSaves() {
+        val metadata =
+            OutputMetadata(
+                entryId = entryId,
+                cacheId = cacheId,
+                createdAtEpochMs = 1L,
+                images =
+                    listOf(
+                        ImageOutputRef(
+                            page = 1,
+                            uri = "content://media/external/images/media/43",
+                            pending = true,
+                        ),
+                    ),
+            )
+
+        assertThrows(IOException::class.java) {
+            existingCompleteImagesForSave(metadata, pageCount = 1)
+        }
+    }
+
+    @Test
     fun outputFingerprintRoundTripsAndRejectsIncompleteOrMalformedPairs() {
         val metadata =
             OutputMetadata(
@@ -236,7 +323,7 @@ class OutputMetadataTest {
         sidecar.writeText("not json")
         assertNull(readOutputMetadata(directory, cacheId, pageCount = 1))
 
-        sidecar.writeText(validJson().replace("\"version\":1", "\"version\":2"))
+        sidecar.writeText(validJson().replace("\"version\":1", "\"version\":99"))
         assertNull(readOutputMetadata(directory, cacheId, pageCount = 1))
 
         sidecar.writeBytes(ByteArray(MAX_OUTPUT_METADATA_BYTES + 1))

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -44,6 +44,12 @@ class PureLogicTest {
     }
 
     @Test
+    fun automaticPdfSaveDefersCustomSafUntilExplicitSave() {
+        assertTrue(automaticPdfUsesDownloads(null))
+        assertFalse(automaticPdfUsesDownloads("content://documents/tree/scanit"))
+    }
+
+    @Test
     fun recentDeleteChoicesUseOnlyExactDurableReferences() {
         assertEquals(
             listOf(RecentDeleteTarget.Pdf, RecentDeleteTarget.Images, RecentDeleteTarget.Both),

--- a/app/src/test/java/com/majkeylab/scanit/RecentScanTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/RecentScanTest.kt
@@ -146,6 +146,58 @@ class RecentScanTest {
         }
 
     @Test
+    fun pendingMediaOwnershipStaysHiddenUntilProviderPublicationCompletes() =
+        withShareRoot { root ->
+            val id = "Scan_pending_outputs"
+            val directory = createEntry(root, id)
+            val entryId = "123e4567-e89b-12d3-a456-426614174000"
+            initializeOutputMetadata(directory, id, 1, 100L, entryId)
+            rewriteOutputMetadata(directory, id, entryId, 1) {
+                it.copy(
+                    pdf =
+                        PdfOutputRef(
+                            uri = "content://media/external/downloads/1",
+                            treeUri = null,
+                            displayName = "scan.pdf",
+                            mimeType = "application/pdf",
+                            ownerPackageName = "com.majkeylab.scanit.internal",
+                            byteLength = 1L,
+                            sha256 = "00".repeat(32),
+                            pending = true,
+                        ),
+                    images =
+                        listOf(
+                            ImageOutputRef(
+                                page = 1,
+                                uri = "content://media/external/images/media/1",
+                                displayName = "scan.jpg",
+                                mimeType = "image/jpeg",
+                                ownerPackageName = "com.majkeylab.scanit.internal",
+                                byteLength = 1L,
+                                sha256 = "11".repeat(32),
+                                pending = true,
+                            ),
+                        ),
+                )
+            }
+
+            val recent = listRecentScansInRoot(root).single()
+
+            assertFalse(recent.hasSavedPdf)
+            assertEquals(0, recent.savedImageCount)
+
+            rewriteOutputMetadata(directory, id, entryId, 1) { metadata ->
+                metadata.copy(
+                    pdf = metadata.pdf?.copy(pending = false),
+                    images = metadata.images.map { it.copy(pending = false) },
+                )
+            }
+            val published = listRecentScansInRoot(root).single()
+            assertTrue(published.hasSavedPdf)
+            assertEquals(1, published.savedImageCount)
+        }
+
+    @Test
     fun fixedMetadataTempCompanionDoesNotInvalidateCoreEntry() = withShareRoot { root ->
         val id = "Scan_with_temp"
         val directory = createEntry(root, id)
@@ -175,7 +227,7 @@ class RecentScanTest {
         val variants =
             listOf(
                 "unknown" to
-                    """{"version":2,"entryId":"123e4567-e89b-12d3-a456-426614174000","cacheId":"Scan_unknown","createdAtEpochMs":1,"images":[]}"""
+                    """{"version":99,"entryId":"123e4567-e89b-12d3-a456-426614174000","cacheId":"Scan_unknown","createdAtEpochMs":1,"images":[]}"""
                         .toByteArray(),
                 "duplicate" to
                     """{"version":1,"entryId":"123e4567-e89b-12d3-a456-426614174000","cacheId":"Scan_duplicate","createdAtEpochMs":1,"images":[{"page":1,"uri":"content://media/images/1"},{"page":1,"uri":"content://media/images/2"}]}"""
@@ -601,6 +653,91 @@ class RecentScanTest {
         }
 
     @Test
+    fun checkpointRecoveryActivatesAnInitialScanWithoutPruningBeforeAuthority() =
+        withShareRoot { root ->
+            val oldIds =
+                (1..8).map { index ->
+                    "Scan_old_$index".also { id ->
+                        createEntry(root, id).apply { assertTrue(setLastModified(index.toLong())) }
+                    }
+                }
+            val candidateId = "Scan_initial"
+            val pending =
+                createEntry(
+                    root,
+                    ".pending-initial",
+                    sourcePageCount = 1,
+                    fileBaseName = candidateId,
+                ).apply {
+                    writeScanAppearanceMetadata(
+                        directory = this,
+                        appearanceSettings = ScanAppearanceSettings(),
+                        pdfSizeTarget = PdfSizeTarget.Original,
+                        lineageCacheId = candidateId,
+                    )
+                }
+            val cache = RecentScanCache(root)
+
+            cache.publishProvisional(pending, File(root, candidateId))
+            assertEquals(oldIds.toSet(), cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet())
+
+            val activated = cache.activateCheckpointProvisional(candidateId, maxEntries = 8)
+
+            assertEquals(candidateId, activated.baseName)
+            assertFalse(cache.isProvisional(candidateId))
+            assertEquals(
+                (oldIds.drop(1) + candidateId).toSet(),
+                cache.list(maxEntries = 8).map(RecentScan::cacheId).toSet(),
+            )
+        }
+
+    @Test
+    fun activationPruneKeepsSidecarOwnedPendingMedia() = withShareRoot { root ->
+        val ownedId = "Scan_pending_owned"
+        val ownedEntryId = "123e4567-e89b-12d3-a456-426614174000"
+        val ownedDirectory = createEntry(root, ownedId)
+        initializeOutputMetadata(ownedDirectory, ownedId, 1, 1L, ownedEntryId)
+        rewriteOutputMetadata(ownedDirectory, ownedId, ownedEntryId, 1) {
+            it.copy(
+                pdf =
+                    PdfOutputRef(
+                        uri = "content://media/external/downloads/1",
+                        treeUri = null,
+                        displayName = "scan.pdf",
+                        mimeType = "application/pdf",
+                        ownerPackageName = "com.majkeylab.scanit.internal",
+                        byteLength = 1L,
+                        sha256 = "00".repeat(32),
+                        pending = true,
+                    ),
+            )
+        }
+        assertTrue(ownedDirectory.setLastModified(1L))
+        val disposableId = "Scan_disposable"
+        createEntry(root, disposableId).apply { assertTrue(setLastModified(2L)) }
+        val candidateId = "Scan_initial"
+        val pending =
+            createEntry(root, ".pending-initial", fileBaseName = candidateId).apply {
+                writeScanAppearanceMetadata(
+                    directory = this,
+                    appearanceSettings = ScanAppearanceSettings(),
+                    lineageCacheId = candidateId,
+                )
+            }
+        val cache = RecentScanCache(root)
+        cache.publishProvisional(pending, File(root, candidateId))
+
+        cache.activateCheckpointProvisional(candidateId, maxEntries = 2)
+
+        assertTrue(ownedDirectory.isDirectory)
+        assertFalse(File(root, disposableId).exists())
+        assertEquals(
+            setOf(ownedId, candidateId),
+            cache.list(maxEntries = 2).map(RecentScan::cacheId).toSet(),
+        )
+    }
+
+    @Test
     fun checkpointRecoveryActivatesWhenThePriorLineageRevisionIsAlreadyGone() =
         withShareRoot { root ->
             val unrelatedId = "Scan_unrelated"
@@ -815,6 +952,36 @@ class RecentScanTest {
         } finally {
             assertTrue(durableOutput.delete())
         }
+    }
+
+    @Test
+    fun automaticPruneKeepsSidecarOwnedPendingMedia() = withShareRoot { root ->
+        val pendingId = "Scan_pending_owned"
+        val pendingEntryId = "123e4567-e89b-12d3-a456-426614174000"
+        val pendingDirectory = createEntry(root, pendingId)
+        initializeOutputMetadata(pendingDirectory, pendingId, 1, 1L, pendingEntryId)
+        rewriteOutputMetadata(pendingDirectory, pendingId, pendingEntryId, 1) {
+            it.copy(
+                pdf =
+                    PdfOutputRef(
+                        uri = "content://media/external/downloads/1",
+                        treeUri = null,
+                        displayName = "scan.pdf",
+                        mimeType = "application/pdf",
+                        ownerPackageName = "com.majkeylab.scanit.internal",
+                        byteLength = 1L,
+                        sha256 = "00".repeat(32),
+                        pending = true,
+                    ),
+            )
+        }
+        assertTrue(pendingDirectory.setLastModified(1L))
+        createEntry(root, "Scan_newer").apply { assertTrue(setLastModified(2L)) }
+
+        val listed = listRecentScansInRoot(root, maxEntries = 1)
+
+        assertEquals(listOf(pendingId), listed.map(RecentScan::cacheId))
+        assertTrue(pendingDirectory.isDirectory)
     }
 
     @Test


### PR DESCRIPTION
Closes #17

- publish initial scans provisionally before authority
- journal pending MediaStore ownership before publication
- preserve owned pending outputs during retention
- defer custom SAF auto-save to explicit File details confirmation
- recover checkpoint and pending publication deterministically

Verification:
- clean testInternalDebugUnitTest: 303 tests, 0 failures/errors
- lintInternalDebug: pass
- assembleInternalDebug: pass
- git diff --check: pass

Device QA remains pending because wireless ADB is offline; host fault-injection tests cover the crash boundaries.