### PR TITLE
fix: replace unsupported Android hard links

### DIFF
--- a/app/src/main/java/com/majkeylab/scanit/JpegPdfWriter.kt
+++ b/app/src/main/java/com/majkeylab/scanit/JpegPdfWriter.kt
@@ -54,28 +54,8 @@ internal object JpegPdfWriter {
 internal fun publishStagedFileNoReplace(
     staging: Path,
     target: Path,
-    deleteIfExists: (Path) -> Boolean = Files::deleteIfExists,
 ) {
-    var published = false
-    try {
-        Files.createLink(target, staging)
-        published = true
-        deleteIfExists(staging)
-    } catch (failure: Throwable) {
-        if (published) {
-            try {
-                if (
-                    Files.exists(target) &&
-                    (!Files.exists(staging) || Files.isSameFile(target, staging))
-                ) {
-                    deleteIfExists(target)
-                }
-            } catch (rollbackFailure: Throwable) {
-                failure.addSuppressed(rollbackFailure)
-            }
-        }
-        throw failure
-    }
+    Files.move(staging, target)
 }
 
 private fun writeJpegPdf(

--- a/app/src/main/java/com/majkeylab/scanit/MarkTemplateStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/MarkTemplateStorage.kt
@@ -211,8 +211,7 @@ internal fun atomicSaveMarkTemplate(
             output.flush()
             output.fd.sync()
         }
-        Files.createLink(target.toPath(), temporary.toPath())
-        temporary.delete()
+        publishStagedFileNoReplace(temporary.toPath(), target.toPath())
     } catch (error: Exception) {
         runCatching { Files.deleteIfExists(temporary.toPath()) }
             .exceptionOrNull()

--- a/app/src/main/java/com/majkeylab/scanit/ScanPdfBuilder.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanPdfBuilder.kt
@@ -78,7 +78,7 @@ internal fun buildScanPdf(
                 val targetMet = target.maxBytes?.let { candidateBytes <= it } ?: true
                 if (selected == null || candidateBytes < selected.bytes) {
                     val retained = File(workingDirectory, "candidate-$sampleMultiplier.pdf")
-                    Files.createLink(retained.toPath(), chosen.toPath())
+                    publishStagedFileNoReplace(chosen.toPath(), retained.toPath())
                     val previous = selected
                     selected =
                         ScanPdfCandidate(sampleMultiplier, candidateBytes, encoding, retained)
@@ -163,7 +163,7 @@ private fun createPdfPublicationStaging(parent: File, candidate: File): Path {
     val staging = Files.createTempFile(parent.toPath(), ".scanit-pdf-ready-", ".part")
     try {
         Files.delete(staging)
-        Files.createLink(staging, candidate.toPath())
+        publishStagedFileNoReplace(candidate.toPath(), staging)
         return staging
     } catch (failure: Throwable) {
         try {

--- a/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
@@ -198,7 +198,7 @@ internal fun writeMarkedSourcePages(
                 if (index == selectedPageIndex) {
                     renderSelectedPage(source, target)
                 } else {
-                    Files.createLink(target.toPath(), source.toPath())
+                    copyDerivedSourcePage(source, target)
                 }
                 if (!target.isFile || target.length() <= 0L) {
                     throw IOException("Marked scan source page is incomplete")
@@ -212,6 +212,26 @@ internal fun writeMarkedSourcePages(
             } catch (cleanupFailure: Exception) {
                 failure.addSuppressed(cleanupFailure)
             }
+        }
+        throw failure
+    }
+}
+
+internal fun copyDerivedSourcePage(source: File, target: File) {
+    if (!source.isFile || source.length() <= 0L) {
+        throw IOException("Derived scan source page is unavailable")
+    }
+    if (target.exists()) throw IOException("Derived scan source target already exists")
+    try {
+        Files.copy(source.toPath(), target.toPath())
+        if (!target.isFile || target.length() != source.length()) {
+            throw IOException("Derived scan source page is incomplete")
+        }
+    } catch (failure: Throwable) {
+        try {
+            Files.deleteIfExists(target.toPath())
+        } catch (cleanupFailure: Exception) {
+            failure.addSuppressed(cleanupFailure)
         }
         throw failure
     }
@@ -1377,7 +1397,7 @@ internal class ScanStorage(
                 val sourcePages =
                     source.sourcePages.mapIndexed { index, page ->
                         File(workDirectory, scanSourcePageFileName(baseName, index + 1)).also {
-                            Files.createLink(it.toPath(), page.toPath())
+                            copyDerivedSourcePage(page, it)
                         }
                     }
                 val renderedPages =

--- a/app/src/test/java/com/majkeylab/scanit/JpegPdfWriterTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/JpegPdfWriterTest.kt
@@ -85,27 +85,16 @@ class JpegPdfWriterTest {
     }
 
     @Test
-    fun publicationRollsBackTargetWhenStagingCleanupFails() {
-        val root = Files.createTempDirectory("scanit-pdf-publication").toFile()
+    fun atomicPublicationMovesTheStagingFileWithoutCreatingAHardLink() {
+        val root = Files.createTempDirectory("scanit-pdf-publication-move").toFile()
         try {
             val staging = File(root, "staging.part").apply { writeText("complete") }
             val target = File(root, "scan.pdf")
 
-            val failure =
-                assertThrows(IOException::class.java) {
-                    publishStagedFileNoReplace(
-                        staging.toPath(),
-                        target.toPath(),
-                        deleteIfExists = { path ->
-                            if (path == staging.toPath()) throw IOException("cleanup failed")
-                            Files.deleteIfExists(path)
-                        },
-                    )
-                }
+            publishStagedFileNoReplace(staging.toPath(), target.toPath())
 
-            assertEquals("cleanup failed", failure.message)
-            assertFalse(target.exists())
-            assertTrue(staging.isFile)
+            assertFalse(staging.exists())
+            assertEquals("complete", target.readText())
         } finally {
             assertTrue(root.deleteRecursively())
         }

--- a/app/src/test/java/com/majkeylab/scanit/MarkTemplateStorageTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/MarkTemplateStorageTest.kt
@@ -146,4 +146,16 @@ class MarkTemplateStorageTest {
         assertFalse(File(directory, "mark_2.png").exists())
         assertEquals(listOf("mark_1.png"), directory.listFiles()?.map(File::getName))
     }
+
+    @Test
+    fun atomicPublishMovesTheTemporaryFileWithoutCreatingAHardLink() {
+        val directory = temporaryFolder.newFolder("atomic-move")
+        val temporary = File(directory, ".mark_1.tmp").apply { writeBytes(byteArrayOf(4, 2)) }
+        val target = File(directory, "mark_1.png")
+
+        publishStagedFileNoReplace(temporary.toPath(), target.toPath())
+
+        assertFalse(temporary.exists())
+        assertArrayEquals(byteArrayOf(4, 2), target.readBytes())
+    }
 }

--- a/app/src/test/java/com/majkeylab/scanit/VisualMarkApplyTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/VisualMarkApplyTest.kt
@@ -159,6 +159,19 @@ class VisualMarkApplyTest {
         assertEquals(emptyList<String>(), workDirectory.listFiles().orEmpty().map(File::getName))
     }
 
+    @Test
+    fun derivedSourceCopyIsIndependentFromTheOriginalFile() {
+        val directory = temporaryFolder.newFolder("source-copy")
+        val source = File(directory, "source.jpg").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val target = File(directory, "derived.jpg")
+
+        copyDerivedSourcePage(source, target)
+        target.writeBytes(byteArrayOf(9))
+
+        assertArrayEquals(byteArrayOf(1, 2, 3), source.readBytes())
+        assertArrayEquals(byteArrayOf(9), target.readBytes())
+    }
+
     private fun savedScan(cacheId: String): SavedScan =
         SavedScan(
             cached =


### PR DESCRIPTION
## Fix
- replace app-private hard-link publication with same-directory no-replace moves
- copy immutable source pages for derived scans
- keep destination race protection and cleanup behavior

## Root cause
Android SELinux denied Files.createLink() in app-private storage. Saved marks and derived mark/appearance PDFs failed on device.

## Verification
- 312 JVM tests, lintInternalDebug, assembleInternalDebug
- Play/GitHub release Gradle tasks passed; signing verification deferred to main checkout where ignored keystore.properties exists
- API 35 emulator: Draw/Save, image import, mark Apply, appearance Apply, force-stop restore, Share PDF, Print, Result/Recent/scanner Back
- generated marked + appearance PDFs parsed by Poppler
- no FATAL, OOM, or remaining Files.createLink call