### PR TITLE
docs: refresh release marketing copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes are documented here.
 - Prepared the source-visible proprietary license for the first new release at `v1.2.0-beta.1` while preserving every historical MIT grant.
 - Removed cloud processing and app-owned network access from the public Google Play and GitHub variants.
 - Added a Recent scans dashboard for bounded, temporary working copies.
+- Added lazy multi-page result browsing with bounded thumbnails.
+- Added remembered color, grayscale, and black-and-white intensity controls with shadow adjustment.
+- Added measured Original, 5 MB, 10 MB, and 20 MB PDF size goals with an honest target-miss warning.
+- Added manual PDF/image saving, exact saved-output deletion, and optional deletion after a sharing app is chosen.
+- Added reusable visual marks for a selected page, with an explicit non-digital-signature disclaimer.
 - Added a static privacy, terms, support, and product site for GitHub Pages.
 - Updated Google Play listing and App Content/Data Safety worksheets for the public no-cloud build.
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,29 @@ main scanning path.
 ScanIt was built with AI-assisted coding and design. The maintainer reviews the
 source, release artifacts, and real-device workflows.
 
+<p align="center">
+  <img src="docs/play-store/assets/en-US/phone/03-result.png" width="30%" alt="ScanIt result with PDF sharing, image sharing, printing, and a new-scan action.">
+  <img src="docs/play-store/assets/en-US/phone/04-recent.png" width="30%" alt="Recent scans with a document preview, page count, file size, and actions.">
+  <img src="docs/play-store/assets/en-US/phone/05-visual-mark.png" width="30%" alt="Visual mark editor placing a SAMPLE mark on a scanned page.">
+</p>
+
+[See all English and Czech screenshots](docs/play-store/assets/).
+
 ## Features
 
 - Opens Google ML Kit Document Scanner directly; no redundant landing-page tap.
 - Automatic capture, edge detection, crop, rotation, filters, shadow removal, and cleanup through the ML Kit scanner flow.
 - Single-page and multi-page PDF/JPEG output.
+- Lazy page thumbnails for browsing multi-page results without decoding every page at once.
+- Color, grayscale, and black-and-white appearance controls with per-filter intensity and shadow strength.
+- Measured PDF size goals of Original, 5 MB, 10 MB, or 20 MB; ScanIt reports the actual size when a readable result cannot meet the selected goal.
 - Recent scans dashboard for up to eight bounded temporary working copies.
 - Automatic PDF and Gallery saving, each configurable in Settings.
+- Manual PDF, image, or combined saving from File details.
 - Optional PDF destination selected with Android's Storage Access Framework.
 - PDF/image sharing with configurable email subject and message.
+- Optional exact deletion of saved PDFs or Gallery images from Recent scans or after a sharing app is chosen.
+- Reusable drawn, imported, or scanned visual marks placed on a selected page. These are image annotations, not digital or cryptographic signatures.
 - Android system printing with page-range support.
 - Monochrome light/dark UI and system/English/Czech language selection.
 - No account, ads, subscription, first-party analytics, cloud document library, or public cloud-processing feature.
@@ -112,7 +126,7 @@ passwords must never enter Git.
 | UI | One Activity, Jetpack Compose, Material 3 |
 | Scanner | Google ML Kit Document Scanner |
 | Storage | MediaStore, Storage Access Framework, bounded app cache |
-| PDF | Android `PdfDocument` / `PrintedPdfDocument` |
+| PDF | Bounded JPEG/bitonal writers + Android `PrintedPdfDocument` for printing |
 | Sharing | Android Sharesheet + scoped `FileProvider` |
 | Settings | `SharedPreferences` |
 
@@ -122,6 +136,7 @@ passwords must never enter Git.
 - Recent scans are temporary working copies, not a permanent document library.
 - Android 17 has no `maxSdk` restriction but has not yet been device-tested.
 - Google Play publication is still in testing; do not describe the app as a production Play release yet.
+- Visual marks do not verify identity, authorization, or document integrity.
 - The repository does not contain production signing material.
 
 ## Feedback

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -56,17 +56,22 @@ the Play developer account.
 > - automatic document detection and capture
 > - crop, perspective correction, rotation, filters, shadow removal, and cleanup
 > - single-page and multi-page PDF and JPEG output
-> - Recent scans with page previews
+> - page thumbnails for browsing multi-page results
+> - color, grayscale, and black-and-white controls with adjustable intensity and shadows
+> - measured Original, 5 MB, 10 MB, and 20 MB PDF size goals
+> - Recent scans with page previews and saved-output deletion
 > - automatic or manual saving of PDFs and Gallery images
 > - PDF saving to Downloads or a folder you choose
 > - PDF/image sharing with an optional subject and message
 > - optional deletion of saved PDFs or images after sharing
-> - deletion of saved outputs from Recent scans
+> - reusable visual marks placed on a selected page
 > - Android system printing
 > - monochrome light and dark interface
 > - system, English, and Czech language selection
 >
 > ScanIt has no ads, subscription, account, first-party analytics, cloud document library, or public cloud-processing feature. Scanned document content stays on the device unless you choose to share or print it.
+>
+> Visual marks are image annotations only. They are not digital or cryptographic signatures and do not verify identity or document integrity. PDF size limits are measured goals; if a readable file cannot meet the selected goal, ScanIt keeps the smallest readable result and shows its actual size.
 >
 > The scanner is powered by Google ML Kit Document Scanner and requires Google Play services. Google Play services may download the scanner module and process limited diagnostic and usage telemetry.
 
@@ -92,23 +97,28 @@ the Play developer account.
 > - automatická detekce a zachycení dokumentu
 > - ořez, korekce perspektivy, otočení, filtry, odstranění stínů a vyčištění
 > - jednostránkový i vícestránkový výstup do PDF a JPEG
-> - Nedávné skeny s náhledy stránek
+> - náhledy stránek pro procházení vícestránkových výsledků
+> - barevný, šedotónový a černobílý režim s nastavitelnou intenzitou a stíny
+> - měřené cíle velikosti PDF: Původní, 5 MB, 10 MB a 20 MB
+> - Nedávné skeny s náhledy a mazáním uložených výstupů
 > - automatické nebo ruční ukládání PDF a obrázků do Galerie
 > - ukládání PDF do Stažených souborů nebo zvolené složky
 > - sdílení PDF nebo obrázků s volitelným předmětem a zprávou
 > - volitelné smazání uložených PDF nebo obrázků po sdílení
-> - mazání uložených výstupů v Nedávných skenech
+> - opakovaně použitelné vizuální značky umístěné na vybranou stránku
 > - systémový tisk Androidu
 > - černobílé světlé i tmavé rozhraní
 > - systémový, anglický a český jazyk
 >
 > ScanIt neobsahuje reklamy, předplatné, účet, vlastní analytické nástroje, cloudovou knihovnu dokumentů ani veřejnou funkci cloudového zpracování. Obsah skenu zůstává v zařízení, dokud ho sami nesdílíte nebo nevytisknete.
 >
+> Vizuální značky jsou pouze obrázkové anotace. Nejde o digitální ani kryptografické podpisy a nepotvrzují totožnost ani neporušenost dokumentu. Limity velikosti PDF jsou měřené cíle; pokud je nelze dodržet při zachování čitelnosti, ScanIt ponechá nejmenší čitelný výsledek a zobrazí jeho skutečnou velikost.
+>
 > Skener používá Google ML Kit Document Scanner a vyžaduje služby Google Play. Služby Google Play mohou stáhnout modul skeneru a zpracovávat omezené diagnostické a provozní údaje.
 
 The listing describes current implemented public behavior only. It does not
-advertise compression targets, signatures, stamps, cloud processing, donations,
-or any other unfinished feature.
+claim certificate-backed signatures, guaranteed PDF compression, cloud
+processing, donations, or any unfinished feature.
 
 ## App Content worksheet
 
@@ -269,16 +279,16 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 5, version `1.2.0-beta.1`.
-- [ ] R8 mapping and real native debug symbols from that exact build are retained for upload.
-- [ ] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
-- [ ] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.
-- [ ] In-app Privacy Policy link opens the Pages URL above.
-- [ ] Pages root, Privacy, and Terms URLs return successfully over HTTPS.
-- [ ] Listing text matches the device-tested feature set.
-- [ ] English and Czech short descriptions remain within 80 characters.
-- [ ] Data Safety answers are rechecked against the exact runtime graph and current official guidance.
-- [ ] Developer identity and public contact fields use verified Play account data.
+- [x] Signed AAB is exactly `com.majkeylab.scanit`, version code 5, version `1.2.0-beta.1`.
+- [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
+- [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
+- [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.
+- [x] In-app Privacy Policy link opens the Pages URL above.
+- [x] Pages root, Privacy, and Terms URLs return successfully over HTTPS.
+- [x] Listing text matches the device-tested feature set.
+- [x] English and Czech short descriptions remain within 80 characters.
+- [x] Data Safety answers are rechecked against the exact runtime graph and current official guidance.
+- [x] Developer identity and public contact fields use verified Play account data.
 - [x] App icon, feature graphic, screenshots, and alt text pass the current asset rules.
-- [ ] No account credentials are entered in App access because none are required.
+- [x] No account credentials are entered in App access because none are required.
 - [ ] Closed/production submission happens only after the signed artifact and all declarations receive final account-holder review.

--- a/docs/reddit/POST.md
+++ b/docs/reddit/POST.md
@@ -1,0 +1,52 @@
+# Reddit update package
+
+Use this after the closed-test review completes. Replace an existing post or
+comment with the same facts; do not describe ScanIt as a production release.
+
+## Title
+
+I built a minimal, local Android document scanner — ScanIt closed beta
+
+## Body
+
+I wanted document scanning to be one short flow: open the app, scan, review,
+then save or share.
+
+ScanIt now supports multi-page scans, Recent scans, page previews, PDF and JPEG
+sharing, printing, manual or automatic local saving, and exact deletion of saved
+outputs that ScanIt can verify it created. You can also adjust
+color/grayscale/black-and-white intensity and
+shadows, choose a measured PDF size goal, and add a reusable visual mark to one
+page.
+
+The visual mark is only an image annotation. It is not a digital or
+cryptographic signature and does not verify identity or document integrity.
+PDF size options are measured goals, not a lossless-compression promise; if a
+readable result cannot meet the selected size, the app shows the actual size.
+
+The public build has no ads, account, subscription, first-party analytics,
+cloud document library, or app-owned Internet permission. Scanned content stays
+on the device unless you choose to share or print it. The scanner uses Google
+ML Kit Document Scanner through Google Play services.
+
+The source is visible for review, but current material is proprietary rather
+than open source. Historical MIT releases keep their original MIT license.
+
+Closed test (available after Google completes the current review):
+https://play.google.com/apps/testing/com.majkeylab.scanit
+
+Feedback is useful, especially around multi-page scans, PDF size goals, and
+device-specific sharing or printing behavior. Please do not send private
+documents in bug reports.
+
+## Gallery order
+
+1. `../play-store/assets/en-US/phone/01-capture.png`
+2. `../play-store/assets/en-US/phone/02-review.png`
+3. `../play-store/assets/en-US/phone/03-result.png`
+4. `../play-store/assets/en-US/phone/04-recent.png`
+5. `../play-store/assets/en-US/phone/05-visual-mark.png`
+6. `../play-store/assets/en-US/phone/06-settings.png`
+
+All gallery images are real UI captures. Do not add a generated device frame,
+private document, personal signature, price claim, ranking, or Google branding.


### PR DESCRIPTION
## Summary
- add real screenshot gallery to README
- document shipped appearance, PDF-size, page-browser, save/delete, and visual-mark behavior
- add paste-ready Reddit update package
- sync Play Console worksheet with verified current behavior and submission evidence

## Verification
- git diff --check
- all six referenced English gallery files exist
- Play Console accepted EN 71/80 and CS 70/80 short descriptions
- updated EN/CS listing copy and screenshots are staged but intentionally not submitted, avoiding restart of the active Alpha review