### PR TITLE
feat: add direct signature placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 All notable changes are documented here.
 
-## [Unreleased]
+## [1.2.0-beta.2] - 2026-08-12
 
 ### Changed
 
-- Prepared the source-visible proprietary license for the first new release at `v1.2.0-beta.1` while preserving every historical MIT grant.
+- Prepared the source-visible proprietary license for the first new release at `v1.2.0-beta.2` while preserving every historical MIT grant.
 - Removed cloud processing and app-owned network access from the public Google Play and GitHub variants.
 - Added a Recent scans dashboard for bounded, temporary working copies.
 - Added lazy multi-page result browsing with bounded thumbnails.
 - Added remembered color, grayscale, and black-and-white intensity controls with shadow adjustment.
 - Added measured Original, 5 MB, 10 MB, and 20 MB PDF size goals with an honest target-miss warning.
 - Added manual PDF/image saving, exact saved-output deletion, and optional deletion after a sharing app is chosen.
-- Added reusable visual marks for a selected page, with an explicit non-digital-signature disclaimer.
+- Added reusable drawn, imported, or scanned signatures and stamps for a selected page, with direct drag placement and an explicit non-digital-signature disclaimer.
 - Added a static privacy, terms, support, and product site for GitHub Pages.
 - Updated Google Play listing and App Content/Data Safety worksheets for the public no-cloud build.
 
@@ -44,3 +44,4 @@ Historical copies retain the license supplied with them. See
 
 [1.0.0-preview.1]: https://github.com/Majkey25/ScanIt/releases/tag/v1.0.0-preview.1
 [1.1.0-alpha.1]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...main
+[1.2.0-beta.2]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...v1.2.0-beta.2

--- a/HISTORICAL_MIT_RELEASES.md
+++ b/HISTORICAL_MIT_RELEASES.md
@@ -1,7 +1,7 @@
 # Historical MIT releases
 
 ScanIt changed to source-visible proprietary terms for new material at the
-license-cutoff commit planned for release as `v1.2.0-beta.1`.
+license-cutoff commit planned for release as `v1.2.0-beta.2`.
 
 The change is prospective. It does not revoke rights granted for any copy that
 was already distributed under the MIT License. Those copies may continue to be

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ source, release artifacts, and real-device workflows.
 - Optional PDF destination selected with Android's Storage Access Framework.
 - PDF/image sharing with configurable email subject and message.
 - Optional exact deletion of saved PDFs or Gallery images from Recent scans or after a sharing app is chosen.
-- Reusable drawn, imported, or scanned visual marks placed on a selected page. These are image annotations, not digital or cryptographic signatures.
+- Reusable drawn, imported, or scanned signatures and stamps, dragged directly into place on a selected page. These are image annotations, not digital or cryptographic signatures.
 - Android system printing with page-range support.
 - Monochrome light/dark UI and system/English/Czech language selection.
 - No account, ads, subscription, first-party analytics, cloud document library, or public cloud-processing feature.
@@ -55,11 +55,11 @@ source, release artifacts, and real-device workflows.
 
 ## Install
 
-The current GitHub stable download is the immutable historical
+The current GitHub prerelease is
+[`v1.2.0-beta.2`](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.0-beta.2).
+The immutable historical
 [`v1.0.0-preview.1`](https://github.com/Majkey25/ScanIt/releases/tag/v1.0.0-preview.1)
-APK. It keeps the MIT license and signature that accompanied that release. The
-new public `1.2.0-beta.1` Google Play and GitHub variants are being prepared and
-are not represented by that older APK.
+APK keeps the MIT license and signature that accompanied that release.
 
 Requirements for the current public code:
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.1` on 2026-08-09. Its direct runtime dependencies are:
+`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 35
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.2.0-beta.1"
+        versionCode = 6
+        versionName = "1.2.0-beta.2"
     }
 
     signingConfigs {

--- a/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
+++ b/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.1` on 2026-08-09. Its direct runtime dependencies are:
+`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/app/src/main/java/com/majkeylab/scanit/MarkModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/MarkModels.kt
@@ -144,6 +144,26 @@ internal fun resolveMarkRect(
     )
 }
 
+internal fun dragMarkPlacement(
+    pageWidth: Float,
+    pageHeight: Float,
+    markWidth: Int,
+    markHeight: Int,
+    placement: MarkPlacement,
+    deltaX: Float,
+    deltaY: Float,
+): MarkPlacement {
+    require(deltaX.isFinite() && deltaY.isFinite()) { "Mark drag must be finite" }
+    val rect = resolveMarkRect(pageWidth, pageHeight, markWidth, markHeight, placement)
+    val centerX =
+        ((rect.left + rect.right) / 2f + deltaX)
+            .coerceIn(rect.width / 2f, pageWidth - rect.width / 2f)
+    val centerY =
+        ((rect.top + rect.bottom) / 2f + deltaY)
+            .coerceIn(rect.height / 2f, pageHeight - rect.height / 2f)
+    return placement.copy(centerX = centerX / pageWidth, centerY = centerY / pageHeight)
+}
+
 internal fun scaleNormalizedMarkStrokes(
     strokes: List<MarkStroke>,
     width: Int,

--- a/app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt
@@ -12,7 +12,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -56,6 +60,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -70,6 +75,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
@@ -133,7 +139,23 @@ internal fun VisualMarkEditorScreen(
             modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            item { VisualMarkPreview(result.thumbnail, selectedBitmap, editor.placement) }
+            item {
+                VisualMarkPreview(
+                    page = result.thumbnail,
+                    mark = selectedBitmap,
+                    placement = editor.placement,
+                    enabled = selectedBitmap != null && !editor.busy,
+                    onPlacementChange = onPlacementChange,
+                )
+                if (selectedBitmap != null) {
+                    Text(
+                        stringResource(R.string.drag_visual_mark_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
             item {
                 VisualMarkCreationActions(
                     enabled = !editor.busy && editor.templateIds.size < MAX_MARK_TEMPLATES,
@@ -396,13 +418,80 @@ private fun VisualMarkPreview(
     page: Bitmap?,
     mark: Bitmap?,
     placement: MarkPlacement,
+    enabled: Boolean,
+    onPlacementChange: (MarkPlacement) -> Unit,
 ) {
     val paint = remember { AndroidPaint(AndroidPaint.ANTI_ALIAS_FLAG) }
     val description = stringResource(R.string.visual_mark_preview)
+    val currentPlacement by rememberUpdatedState(placement)
+    val currentOnPlacementChange by rememberUpdatedState(onPlacementChange)
     Canvas(
         modifier =
             Modifier.fillMaxWidth().height(300.dp)
                 .background(MaterialTheme.colorScheme.surfaceVariant)
+                .pointerInput(page, mark, enabled) {
+                    val pageBitmap = page ?: return@pointerInput
+                    val markBitmap = mark ?: return@pointerInput
+                    if (!enabled) return@pointerInput
+                    val scale =
+                        min(
+                            size.width.toFloat() / pageBitmap.width,
+                            size.height.toFloat() / pageBitmap.height,
+                        )
+                    val pageWidth = pageBitmap.width * scale
+                    val pageHeight = pageBitmap.height * scale
+                    val left = (size.width - pageWidth) / 2f
+                    val top = (size.height - pageHeight) / 2f
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val initialPlacement = currentPlacement
+                        val rect =
+                            resolveMarkRect(
+                                pageWidth,
+                                pageHeight,
+                                markBitmap.width,
+                                markBitmap.height,
+                                initialPlacement,
+                            )
+                        if (
+                            down.position.x !in (left + rect.left)..(left + rect.right) ||
+                            down.position.y !in (top + rect.top)..(top + rect.bottom)
+                        ) {
+                            return@awaitEachGesture
+                        }
+                        var dragPlacement = initialPlacement
+                        val dragStart =
+                            awaitTouchSlopOrCancellation(down.id) { change, overSlop ->
+                                change.consume()
+                                dragPlacement =
+                                    dragMarkPlacement(
+                                        pageWidth,
+                                        pageHeight,
+                                        markBitmap.width,
+                                        markBitmap.height,
+                                        dragPlacement,
+                                        overSlop.x,
+                                        overSlop.y,
+                                    )
+                                currentOnPlacementChange(dragPlacement)
+                            } ?: return@awaitEachGesture
+                        drag(dragStart.id) { change ->
+                            val dragAmount = change.positionChange()
+                            change.consume()
+                            dragPlacement =
+                                dragMarkPlacement(
+                                    pageWidth = pageWidth,
+                                    pageHeight = pageHeight,
+                                    markWidth = markBitmap.width,
+                                    markHeight = markBitmap.height,
+                                    placement = dragPlacement,
+                                    deltaX = dragAmount.x,
+                                    deltaY = dragAmount.y,
+                                )
+                            currentOnPlacementChange(dragPlacement)
+                        }
+                    }
+                }
                 .semantics { contentDescription = description },
     ) {
         val pageBitmap = page ?: return@Canvas

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -133,7 +133,7 @@
     <string name="visual_mark_template_failed">Podpis nebo razítko se nepodařilo uložit.</string>
     <string name="visual_mark_apply_failed">Podpis nebo razítko se nepodařilo přidat.</string>
     <string name="visual_mark_scanner_failed">Sken podpisu nebo razítka se nepodařilo otevřít.</string>
-    <string name="add_signature_or_stamp">Přidat podpis nebo razítko</string>
+    <string name="add_signature_or_stamp">Podepsat nebo orazítkovat dokument</string>
     <string name="visual_mark_title">Podpis nebo razítko</string>
     <string name="visual_mark_disclaimer">Tato funkce vloží pouze obrázek podpisu nebo razítka. Nejde o digitální ani kryptografický podpis a nepotvrzuje totožnost ani neporušenost dokumentu.</string>
     <string name="saved_visual_marks">Uložené podpisy a razítka</string>
@@ -157,6 +157,7 @@
     <string name="delete_visual_mark_body">Tímto odstraníte vybraný uložený podpis nebo razítko.</string>
     <string name="delete_visual_mark_confirm">Smazat</string>
     <string name="visual_mark_preview">Náhled podpisu nebo razítka</string>
+    <string name="drag_visual_mark_hint">Přetažením podpis umístěte.</string>
     <string name="saved_visual_mark_number">Uložená značka %1$d</string>
     <string name="visual_mark_percent">%1$d %%</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="visual_mark_template_failed">The signature or stamp could not be saved.</string>
     <string name="visual_mark_apply_failed">The signature or stamp could not be added.</string>
     <string name="visual_mark_scanner_failed">The signature or stamp scan could not be opened.</string>
-    <string name="add_signature_or_stamp">Add signature or stamp</string>
+    <string name="add_signature_or_stamp">Sign or stamp document</string>
     <string name="visual_mark_title">Signature or stamp</string>
     <string name="visual_mark_disclaimer">This adds only a visual signature or stamp. It is not a digital or cryptographic signature and does not verify identity or document integrity.</string>
     <string name="saved_visual_marks">Saved signatures and stamps</string>
@@ -155,6 +155,7 @@
     <string name="delete_visual_mark_body">This removes the selected saved signature or stamp.</string>
     <string name="delete_visual_mark_confirm">Delete</string>
     <string name="visual_mark_preview">Signature or stamp preview</string>
+    <string name="drag_visual_mark_hint">Drag the signature to place it.</string>
     <string name="saved_visual_mark_number">Saved mark %1$d</string>
     <string name="visual_mark_percent">%1$d%%</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>

--- a/app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt
@@ -35,6 +35,68 @@ class MarkLogicTest {
     }
 
     @Test
+    fun markDragMovesByPreviewPixelsInNormalizedPageCoordinates() {
+        val moved =
+            dragMarkPlacement(
+                pageWidth = 1_000f,
+                pageHeight = 2_000f,
+                markWidth = 400,
+                markHeight = 200,
+                placement = MarkPlacement(),
+                deltaX = 100f,
+                deltaY = -200f,
+            )
+
+        assertEquals(0.6f, moved.centerX, 0.0001f)
+        assertEquals(0.65f, moved.centerY, 0.0001f)
+        assertEquals(0.35f, moved.widthFraction, 0f)
+    }
+
+    @Test
+    fun markDragClampsActualRectangleToEdgesWithoutDeadZone() {
+        val topLeft =
+            dragMarkPlacement(
+                pageWidth = 1_000f,
+                pageHeight = 2_000f,
+                markWidth = 200,
+                markHeight = 100,
+                placement = MarkPlacement(centerX = 0f, centerY = 0f, widthFraction = 0.4f),
+                deltaX = -100f,
+                deltaY = -100f,
+            )
+        val bottomRight =
+            dragMarkPlacement(
+                pageWidth = 1_000f,
+                pageHeight = 2_000f,
+                markWidth = 200,
+                markHeight = 100,
+                placement = topLeft,
+                deltaX = 10_000f,
+                deltaY = 10_000f,
+            )
+
+        assertEquals(0.2f, topLeft.centerX, 0.0001f)
+        assertEquals(0.05f, topLeft.centerY, 0.0001f)
+        assertRect(MarkRect(0f, 0f, 400f, 200f), resolveMarkRect(1_000f, 2_000f, 200, 100, topLeft))
+        assertEquals(0.8f, bottomRight.centerX, 0.0001f)
+        assertEquals(0.95f, bottomRight.centerY, 0.0001f)
+        assertRect(
+            MarkRect(600f, 1_800f, 1_000f, 2_000f),
+            resolveMarkRect(1_000f, 2_000f, 200, 100, bottomRight),
+        )
+    }
+
+    @Test
+    fun markDragRejectsNonFiniteDeltaAndInvalidGeometry() {
+        assertThrows(IllegalArgumentException::class.java) {
+            dragMarkPlacement(1_000f, 2_000f, 200, 100, MarkPlacement(), Float.NaN, 0f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            dragMarkPlacement(0f, 2_000f, 200, 100, MarkPlacement(), 0f, 0f)
+        }
+    }
+
+    @Test
     fun tallMarkScalesDownWithoutChangingAspect() {
         val rect =
             resolveMarkRect(

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -19,8 +19,8 @@ submitted declarations:
 |---|---|
 | App name | `ScanIt` |
 | Package | `com.majkeylab.scanit` |
-| Version code | `5` |
-| Version name | `1.2.0-beta.1` |
+| Version code | `6` |
+| Version name | `1.2.0-beta.2` |
 | Default language | English (United States) |
 | App or game | App |
 | Category | Productivity |
@@ -64,7 +64,7 @@ the Play developer account.
 > - PDF saving to Downloads or a folder you choose
 > - PDF/image sharing with an optional subject and message
 > - optional deletion of saved PDFs or images after sharing
-> - reusable visual marks placed on a selected page
+> - reusable drawn, imported, or scanned signatures and stamps dragged into place on a selected page
 > - Android system printing
 > - monochrome light and dark interface
 > - system, English, and Czech language selection
@@ -105,7 +105,7 @@ the Play developer account.
 > - ukládání PDF do Stažených souborů nebo zvolené složky
 > - sdílení PDF nebo obrázků s volitelným předmětem a zprávou
 > - volitelné smazání uložených PDF nebo obrázků po sdílení
-> - opakovaně použitelné vizuální značky umístěné na vybranou stránku
+> - opakovaně použitelné kreslené, importované nebo skenované podpisy a razítka přetažené na vybranou stránku
 > - systémový tisk Androidu
 > - černobílé světlé i tmavé rozhraní
 > - systémový, anglický a český jazyk
@@ -279,7 +279,7 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [x] Signed AAB is exactly `com.majkeylab.scanit`, version code 5, version `1.2.0-beta.1`.
+- [x] Signed AAB is exactly `com.majkeylab.scanit`, version code 6, version `1.2.0-beta.2`.
 - [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
 - [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
 - [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.

--- a/docs/superpowers/plans/2026-08-12-direct-signing-release.md
+++ b/docs/superpowers/plans/2026-08-12-direct-signing-release.md
@@ -1,0 +1,235 @@
+# Direct Signing Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add direct drag placement to the existing visual signature/stamp editor and ship verified release `1.2.0-beta.2`.
+
+**Architecture:** Keep `MarkPlacement` as the single editor/rendering source of truth. Add one pure geometry helper in `MarkModels.kt`, call it from a hit-tested Compose drag gesture, and leave the existing storage/render/apply transaction unchanged. Release changes update the existing version/verifier/docs pipeline only.
+
+**Tech Stack:** Kotlin, Jetpack Compose Material 3, Android Bitmap/PDF pipeline, JUnit 4, Gradle, PowerShell release verifier, GitHub CLI.
+
+## Global Constraints
+
+- Visual signature only; never claim certificate-backed, cryptographic, eIDAS, or identity-verified signing.
+- Keep English and Czech with UTF-8 diacritics.
+- No new dependency, permission, navigation layer, cloud service, or account.
+- Version code `6`; version/tag `1.2.0-beta.2` / `v1.2.0-beta.2`.
+- Final installation targets `com.majkeylab.scanit.internal`; never overwrite the stable public package during QA.
+
+---
+
+### Task 1: Pure drag geometry
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/MarkModels.kt`
+- Test: `app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt`
+
+**Interfaces:**
+- Consumes: existing `MarkPlacement`, `resolveMarkRect(...)`.
+- Produces: `dragMarkPlacement(pageWidth, pageHeight, markWidth, markHeight, placement, deltaX, deltaY): MarkPlacement`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests proving a normal drag changes normalized centers, a drag clamps the rendered mark to all page edges without a dead zone, and non-finite/invalid geometry is rejected.
+
+```kotlin
+val moved = dragMarkPlacement(1_000f, 2_000f, 400, 200, MarkPlacement(), 100f, -200f)
+assertEquals(0.6f, moved.centerX, 0.0001f)
+assertEquals(0.65f, moved.centerY, 0.0001f)
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```powershell
+.\gradlew.bat :app:testInternalDebugUnitTest --tests com.majkeylab.scanit.MarkLogicTest --no-daemon --console=plain
+```
+
+Expected: Kotlin test compilation fails only because `dragMarkPlacement` does not exist.
+
+- [ ] **Step 3: Add minimal helper**
+
+Use `resolveMarkRect` to obtain the actual on-page rectangle, move its center by the pixel delta, clamp that center by its half width/height, normalize, and return `placement.copy(centerX = ..., centerY = ...)`.
+
+```kotlin
+internal fun dragMarkPlacement(
+    pageWidth: Float,
+    pageHeight: Float,
+    markWidth: Int,
+    markHeight: Int,
+    placement: MarkPlacement,
+    deltaX: Float,
+    deltaY: Float,
+): MarkPlacement {
+    require(deltaX.isFinite() && deltaY.isFinite()) { "Mark drag must be finite" }
+    val rect = resolveMarkRect(pageWidth, pageHeight, markWidth, markHeight, placement)
+    val centerX = ((rect.left + rect.right) / 2f + deltaX).coerceIn(rect.width / 2f, pageWidth - rect.width / 2f)
+    val centerY = ((rect.top + rect.bottom) / 2f + deltaY).coerceIn(rect.height / 2f, pageHeight - rect.height / 2f)
+    return placement.copy(centerX = centerX / pageWidth, centerY = centerY / pageHeight)
+}
+```
+
+- [ ] **Step 4: Run GREEN**
+
+Run the focused command from Step 2. Expected: all `MarkLogicTest` tests pass.
+
+- [ ] **Step 5: Review diff**
+
+Run `git diff --check` and confirm no duplicate geometry logic or UI dependency entered `MarkModels.kt`.
+
+### Task 2: Direct placement UI and copy
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt`
+- Modify: `app/src/main/res/values/strings.xml`
+- Modify: `app/src/main/res/values-cs/strings.xml`
+- Test: `app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt`
+
+**Interfaces:**
+- Consumes: `dragMarkPlacement(...)`, existing `onPlacementChange` callback.
+- Produces: preview drag behavior; no new ViewModel state.
+
+- [ ] **Step 1: Wire editor state into preview**
+
+Change the preview call to pass `enabled = selectedBitmap != null && !editor.busy` and `onPlacementChange`.
+
+- [ ] **Step 2: Add hit-tested gesture**
+
+Track canvas size and use `detectDragGestures`. At drag start, compute the page rectangle and mark rectangle exactly as preview drawing does. Set an in-gesture Boolean only when the pointer is inside the displayed mark. Consume/move only active mark drags; use `dragMarkPlacement(...)` and the latest placement/callback state.
+
+- [ ] **Step 3: Add concise guidance and signing copy**
+
+Add:
+
+```xml
+<string name="drag_visual_mark_hint">Drag the signature to place it.</string>
+<string name="add_signature_or_stamp">Sign or stamp document</string>
+```
+
+and Czech:
+
+```xml
+<string name="drag_visual_mark_hint">Přetažením podpis umístěte.</string>
+<string name="add_signature_or_stamp">Podepsat nebo orazítkovat dokument</string>
+```
+
+Render the hint below the preview only when a mark is selected. Preserve the disclaimer and the three accessible sliders.
+
+- [ ] **Step 4: Compile and run focused tests**
+
+```powershell
+.\gradlew.bat :app:testInternalDebugUnitTest --tests com.majkeylab.scanit.MarkLogicTest --tests com.majkeylab.scanit.VisualMarkApplyTest :app:lintInternalDebug --no-daemon --console=plain
+```
+
+Expected: focused tests and lint pass.
+
+- [ ] **Step 5: Hostile self-review**
+
+Check pointer cancellation, scroll outside the mark, stale placement capture, busy-state disabling, page/mark null handling, TalkBack slider fallback, and preview/final placement agreement.
+
+### Task 3: Release metadata `1.2.0-beta.2`
+
+**Files:**
+- Modify: `app/build.gradle.kts`
+- Modify: `tools/verify-release.ps1`
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `docs/play-store/PLAY_CONSOLE.md`
+- Modify: `docs/third-party-notices.txt`
+- Modify: `app/src/main/assets/legal/THIRD_PARTY_NOTICES.md`
+
+**Interfaces:**
+- Consumes: repository release gate and current artifact matrix.
+- Produces: version code `6`, version `1.2.0-beta.2`, matching verifier/docs.
+
+- [ ] **Step 1: Update build and verifier**
+
+Set `versionCode = 6`, `versionName = "1.2.0-beta.2"`, and update exact verifier expectations for internal/play/github variants.
+
+- [ ] **Step 2: Update release copy**
+
+Add a changelog section dated `2026-08-12` for direct signature placement and the already-shipped safe visual signing flow. Update current-version references in README, Play worksheet, and both identical third-party notice copies. Do not add certificate-signing claims.
+
+- [ ] **Step 3: Verify notice parity and diff**
+
+```powershell
+Get-FileHash docs\third-party-notices.txt, app\src\main\assets\legal\THIRD_PARTY_NOTICES.md -Algorithm SHA256
+git diff --check
+```
+
+Expected: both notice hashes match; diff check passes.
+
+### Task 4: Full gate and live QA
+
+**Files:**
+- No production file additions.
+- Temporary QA artifacts only under `.reference/tmp`, removed before commit.
+
+**Interfaces:**
+- Consumes: final source and local ignored signing configuration.
+- Produces: verified internal APK, signed Play AAB, signed GitHub APK/AAB.
+
+- [ ] **Step 1: Run full release gate**
+
+```powershell
+.\tools\build.ps1
+```
+
+Expected: clean internal tests/lint/build, Play/GitHub lint/build, and all four artifact verifications pass.
+
+- [ ] **Step 2: Install internal APK**
+
+```powershell
+adb -s <physical-device-serial> install -r app\build\outputs\apk\internal\debug\app-internal-debug.apk
+adb -s <physical-device-serial> shell am start -n com.majkeylab.scanit.internal/com.majkeylab.scanit.MainActivity
+```
+
+Use the physical serial returned by `adb devices -l`. Never substitute the emulator and call it a phone.
+
+- [ ] **Step 3: Exercise live scenarios**
+
+Verify: draw/sign/drag/apply happy path; clamp at an edge; cancel/back negative path; Recent open/share nearby regression; English/Czech copy; no new `FATAL EXCEPTION`, ANR, or OOM. If the phone is unavailable, run the same bounded checks on `emulator-5554` and retain the phone install as an explicit blocker.
+
+- [ ] **Step 4: Record hashes**
+
+Hash internal APK, Play AAB, GitHub APK, GitHub AAB, and `mapping.txt` with SHA-256 for release evidence.
+
+### Task 5: Merge and publish
+
+**Files:**
+- Create: GitHub PR/release records only.
+
+**Interfaces:**
+- Consumes: green local gate, artifact hashes, protected-branch workflow.
+- Produces: merged `main`, tag/release `v1.2.0-beta.2`, downloadable artifacts.
+
+- [ ] **Step 1: Commit minimal code/release changes**
+
+Stage exact files, run staged `git diff --check`, and commit with Conventional Commits.
+
+- [ ] **Step 2: Push branch and open PR**
+
+Push `feat/direct-signing-release/12-08-2026`, open a PR to `main`, and include exact test/build evidence.
+
+- [ ] **Step 3: Wait for required checks and merge**
+
+Do not bypass protection. Merge only after `Test, lint, and build` succeeds. Pull/verify resulting `main` SHA.
+
+- [ ] **Step 4: Rebuild from merged main**
+
+Run `tools/build.ps1` again from exact merged `main`. This post-merge build is release authority.
+
+- [ ] **Step 5: Publish prerelease**
+
+Create annotated tag `v1.2.0-beta.2`, push it, and create a GitHub prerelease with verified GitHub APK/AAB, Play AAB, `mapping.txt`, checksums, and concise notes. Confirm the release page/tag/assets through `gh release view`.
+
+- [ ] **Step 6: Install exact post-merge internal build**
+
+Install the post-merge internal APK on the physical phone and confirm package/version through `dumpsys package`.
+
+## Self-review
+
+- Spec coverage: direct drag, hit test, accessible fallback, legal boundary, release metadata, signed artifacts, protected merge, GitHub release, and physical install all have tasks.
+- Placeholder scan: no TBD/TODO/generic error-handling steps.
+- Type consistency: Task 2 consumes the exact helper signature from Task 1; release version/code match every task.

--- a/docs/superpowers/specs/2026-08-12-direct-signing-release-design.md
+++ b/docs/superpowers/specs/2026-08-12-direct-signing-release-design.md
@@ -1,0 +1,54 @@
+# Direct Signing Release Design
+
+## Goal
+
+Make ScanIt's existing visual signature/stamp feature feel like signing a document: create or reuse a mark, drag it directly on the selected page, size it, apply it, then ship and install version `1.2.0-beta.2`.
+
+## Product boundary
+
+- This is a visual handwritten signature/stamp burned into the selected page.
+- It is not a certificate-backed, cryptographic, eIDAS, or identity-verified digital signature.
+- Keep the existing plain-language disclaimer visible in English and Czech.
+- No new runtime dependency, navigation library, cloud service, account, or permission.
+
+## User flow
+
+1. Result shows `Sign or stamp document` / `Podepsat nebo orazítkovat dokument`.
+2. Opening it keeps the current selected page and saved-mark library.
+3. A first-time user chooses Draw, Import image, or Scan paper. A saved mark remains reusable.
+4. With a mark selected, the user drags the mark itself on the page preview. Dragging elsewhere keeps normal vertical scrolling.
+5. Horizontal, vertical, and size sliders remain as precise and screen-reader-accessible controls.
+6. `Apply to page N` creates a new local scan revision and PDF through the existing guarded mark pipeline.
+
+## Placement behavior
+
+- Dragging is enabled only when the page bitmap and selected mark bitmap are loaded and the editor is not busy.
+- A drag starts only inside the displayed mark rectangle.
+- Pixel drag deltas are converted to normalized page coordinates.
+- The actual rendered mark rectangle remains fully inside the page. Moving away from an edge has no dead zone.
+- The editor state remains owned by `ScanViewModel`; Compose holds no durable placement state.
+- Existing sliders and apply rendering use the same `MarkPlacement` value, so preview and final output match.
+
+## UI
+
+- Keep the current minimal black/white editor and top bar.
+- Add one short hint below the preview: `Drag the signature to place it.` / `Přetažením podpis umístěte.`
+- Keep saved marks, delete confirmation, progress, errors, and disclaimer.
+- Do not add pinch zoom, rotation, free-form transform handles, certificate terminology, or another editor screen.
+
+## Release
+
+- Version code `6`.
+- Version name and tag `1.2.0-beta.2` / `v1.2.0-beta.2`.
+- Update release verifier expectations, changelog, README/release metadata, Play worksheet, and packaged third-party notice version text.
+- Build and verify internal APK, Play AAB, GitHub APK, and GitHub AAB with the repository release gate.
+- Merge through the protected `main` branch by PR after required checks pass.
+- Publish a GitHub prerelease with the verified GitHub APK/AAB and checksums.
+- Install the exact final internal APK on the user's physical phone; do not replace the stable public package.
+
+## Verification
+
+- Unit tests: drag conversion, edge clamping, invalid geometry, and unchanged mark rendering policies.
+- Host gate: all internal tests, all three lint variants, internal APK, Play AAB, GitHub APK/AAB, and artifact verifier.
+- Phone: draw a signature, drag it, apply it to one page, verify resulting PDF/share path, verify Back/cancel and a nearby Recent workflow, then check crash/ANR logs.
+- If the physical phone is not connected, install to the emulator for lower-confidence QA and report the exact ADB connection blocker; do not claim phone installation.

--- a/docs/third-party-notices.txt
+++ b/docs/third-party-notices.txt
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.1` on 2026-08-09. Its direct runtime dependencies are:
+`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -18,7 +18,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "5"
+$expectedVersionCode = "6"
 $expectedMinSdk = "35"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -27,15 +27,15 @@ $sdkRootWasExplicit = $PSBoundParameters.ContainsKey("SdkRoot")
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.2.0-beta.1-internal"
+        $expectedVersionName = "1.2.0-beta.2-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.2.0-beta.1"
+        $expectedVersionName = "1.2.0-beta.2"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.2.0-beta.1"
+        $expectedVersionName = "1.2.0-beta.2"
     }
 }
 


### PR DESCRIPTION
## Summary

- let users drag a selected visual signature or stamp directly on the page preview
- preserve normal page scrolling when the gesture starts outside the mark
- publish version `1.2.0-beta.2` / code `6` release metadata and documentation

## Verification

- focused RED then GREEN tests for pixel movement, edge clamping, and invalid geometry
- `MarkLogicTest` + `VisualMarkApplyTest` + `lintInternalDebug`
- full signed `tools/build.ps1`: 161/161 Gradle tasks executed successfully
- verified internal, Play, and GitHub artifacts with the repository verifier
- emulator: direct drag `53% / 18%` -> `72% / 60%`, outside-mark scroll, apply to page, signed PDF share chooser, Result -> Recent, no FATAL/ANR/OOM

Visual signatures are image annotations. They are not cryptographic or certificate-backed digital signatures.
