### PR TITLE
fix: restore scanner in release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes are documented here.
 
+## [1.1.0] - 2026-08-12
+
+### Fixed
+
+- Preserved the manifest-discovered ML Kit component registrar constructor in minified public builds so the scanner opens from the stable GitHub APK.
+
+### Changed
+
+- Published the current complete feature set as a stable release and simplified the README to one latest-stable APK download link.
+
 ## [1.2.0-beta.2] - 2026-08-12
 
 ### Changed
@@ -43,5 +53,6 @@ Historical copies retain the license supplied with them. See
 [Historical MIT releases](HISTORICAL_MIT_RELEASES.md).
 
 [1.0.0-preview.1]: https://github.com/Majkey25/ScanIt/releases/tag/v1.0.0-preview.1
+[1.1.0]: https://github.com/Majkey25/ScanIt/compare/v1.0.0...v1.1.0
 [1.1.0-alpha.1]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...main
 [1.2.0-beta.2]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...v1.2.0-beta.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml"><img alt="Android CI" src="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml/badge.svg"></a>
-  <a href="https://github.com/Majkey25/ScanIt/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/Majkey25/ScanIt?include_prereleases&amp;sort=semver"></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/latest"><img alt="Latest stable release" src="https://img.shields.io/github/v/release/Majkey25/ScanIt"></a>
   <img alt="Android 15+" src="https://img.shields.io/badge/Android-15%2B-111111">
   <a href="LICENSE"><img alt="Source-visible proprietary license" src="https://img.shields.io/badge/License-Proprietary-111111"></a>
 </p>
@@ -55,11 +55,8 @@ source, release artifacts, and real-device workflows.
 
 ## Install
 
-The current GitHub prerelease is
-[`v1.2.0-beta.2`](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.0-beta.2).
-The immutable historical
-[`v1.0.0-preview.1`](https://github.com/Majkey25/ScanIt/releases/tag/v1.0.0-preview.1)
-APK keeps the MIT license and signature that accompanied that release.
+Download the
+[latest stable GitHub APK](https://github.com/Majkey25/ScanIt/releases/latest/download/app-github-release.apk).
 
 Requirements for the current public code:
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
+`1.1.0` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 35
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.2.0-beta.2"
+        versionCode = 7
+        versionName = "1.1.0"
     }
 
     signingConfigs {
@@ -53,7 +53,10 @@ android {
             signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
             ndk {
                 debugSymbolLevel = "FULL"
             }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+-keep class * implements com.google.firebase.components.ComponentRegistrar {
+    public <init>();
+}

--- a/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
+++ b/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
+`1.1.0` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -19,8 +19,8 @@ submitted declarations:
 |---|---|
 | App name | `ScanIt` |
 | Package | `com.majkeylab.scanit` |
-| Version code | `6` |
-| Version name | `1.2.0-beta.2` |
+| Version code | `7` |
+| Version name | `1.1.0` |
 | Default language | English (United States) |
 | App or game | App |
 | Category | Productivity |
@@ -279,7 +279,7 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [x] Signed AAB is exactly `com.majkeylab.scanit`, version code 6, version `1.2.0-beta.2`.
+- [x] Signed AAB is exactly `com.majkeylab.scanit`, version code 7, version `1.1.0`.
 - [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
 - [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
 - [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.

--- a/docs/third-party-notices.txt
+++ b/docs/third-party-notices.txt
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.0-beta.2` on 2026-08-12. Its direct runtime dependencies are:
+`1.1.0` on 2026-08-12. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -18,7 +18,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "6"
+$expectedVersionCode = "7"
 $expectedMinSdk = "35"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -27,15 +27,15 @@ $sdkRootWasExplicit = $PSBoundParameters.ContainsKey("SdkRoot")
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.2.0-beta.2-internal"
+        $expectedVersionName = "1.1.0-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.2.0-beta.2"
+        $expectedVersionName = "1.1.0"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.2.0-beta.2"
+        $expectedVersionName = "1.1.0"
     }
 }
 
@@ -74,6 +74,17 @@ function Get-AndroidBuildTool {
     $tool = Join-Path $buildTools.FullName $fileName
     if (-not (Test-Path -LiteralPath $tool -PathType Leaf)) {
         throw "Required Android tool is missing: $tool"
+    }
+    return $tool
+}
+
+function Get-AndroidSdkTool {
+    param([Parameter(Mandatory)][string]$Name)
+
+    $fileName = if ($isWindowsHost) { "$Name.bat" } else { $Name }
+    $tool = Join-Path $SdkRoot "cmdline-tools/latest/bin/$fileName"
+    if (-not (Test-Path -LiteralPath $tool -PathType Leaf)) {
+        throw "Required Android SDK tool is missing: $tool"
     }
     return $tool
 }
@@ -274,6 +285,16 @@ if ($artifactType -eq "apk") {
     }
     if ($publicFlavor -and (($resources -join [Environment]::NewLine) -match '(?i)gemini|generativelanguage\.googleapis\.com')) {
         throw "Public release APK contains Gemini resources."
+    }
+    if ($publicFlavor) {
+        $apkanalyzer = Get-AndroidSdkTool -Name "apkanalyzer"
+        $registrarCode = @(& $apkanalyzer dex code --class "com.google.mlkit.common.internal.CommonComponentRegistrar" $artifact 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            throw "apkanalyzer could not inspect the ML Kit component registrar: $($registrarCode -join [Environment]::NewLine)"
+        }
+        if (($registrarCode -join [Environment]::NewLine) -notmatch '(?m)^\.method public constructor <init>\(\)V\r?$') {
+            throw "Public release APK is missing the ML Kit component registrar public no-arg constructor."
+        }
     }
 
     & $zipalign -c -P 16 4 $artifact


### PR DESCRIPTION
## Summary

- preserve the reflective ML Kit `ComponentRegistrar` constructor in minified releases
- add a final-APK verifier regression for the registrar constructor
- set the stable public version to `1.1.0` / code `7`
- simplify README installation to the latest stable GitHub APK

## Root cause

The exact `v1.0.0` GitHub APK failed before scanner launch because R8 removed `CommonComponentRegistrar.<init>()`. Google Play services could not instantiate the manifest-discovered registrar and ScanIt showed `Could not open the scanner.` This is not an app `CAMERA` permission issue.

## Verification

- RED: exact published `v1.0.0` APK rejected by the new verifier for the missing public no-arg constructor
- `tools/build.ps1` -> 161 tasks, BUILD SUCCESSFUL
- all four artifact verifiers passed: Internal APK, Play AAB, GitHub APK, GitHub AAB
- minified `com.majkeylab.scanit.github` `1.1.0` cold launch opened Google Play services `DocumentScanningActivity`
- scanner Back returned to Recent; app Back reopened scanner
- no `Invalid component registrar`, `NoSuchMethodException`, ScanIt `FATAL EXCEPTION`, ANR, or OOM in the QA log
