### PR TITLE
docs: finalize ScanIt v1.2.2 release plan

### DIFF
--- a/docs/superpowers/plans/2026-08-13-public-support-release.md
+++ b/docs/superpowers/plans/2026-08-13-public-support-release.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a policy-safe optional Buy Me a Coffee button to public ScanIt Settings and publish verified `v1.2.1` artifacts.
+**Goal:** Add a policy-safe optional Buy Me a Coffee button to public ScanIt Settings and publish verified `v1.2.2` artifacts.
 
 **Architecture:** Keep the external support link in the existing Settings footer. Add localized resources and no new runtime dependency, permission, state, or abstraction.
 

--- a/docs/superpowers/plans/2026-08-13-public-support-release.md
+++ b/docs/superpowers/plans/2026-08-13-public-support-release.md
@@ -38,5 +38,4 @@
 - [ ] Run `./tools/verify-release.ps1 github ./app/build/outputs/apk/github/release/app-github-release.apk` and verify the GitHub AAB too.
 - [ ] Install only the internal APK on the emulator, open Settings, activate Support ScanIt, and verify the browser receives the expected Buy Me a Coffee HTTPS URL.
 - [ ] Run `git diff --check` and inspect the complete diff.
-- [ ] Commit with `feat: add optional ScanIt support link`, push the feature branch, open a PR into protected `main`, wait for required checks, merge, then create the signed `v1.2.1` GitHub release only from merged `main` artifacts.
-
+- [ ] Commit with `feat: add optional ScanIt support link`, push the feature branch, open a PR into protected `main`, wait for required checks, merge, then create the signed `v1.2.2` GitHub release only from merged `main` artifacts.

--- a/docs/superpowers/specs/2026-08-13-scanit-monetization-design.md
+++ b/docs/superpowers/specs/2026-08-13-scanit-monetization-design.md
@@ -35,4 +35,3 @@ Buy Me a Coffee is a pure optional tip and never unlocks Premium. Premium, ad re
 
 - Public: unit tests, lint, signed Play/GitHub artifact verification, emulator Settings link, and public-manifest check for no Internet/ad/Billing/Gemini material.
 - Beta: pure entitlement tests covering purchased, pending, canceled, restored, duplicate, and acknowledgement states; lint/build; emulator ad/consent/Premium UI; and later Play license-tester purchase, restore, refund/revocation, and pending-payment checks.
-


### PR DESCRIPTION
Removes two trailing blank lines found by the release diff check and corrects the final release-plan tag to v1.2.2. No app or build logic changes.