### PR TITLE
fix: persist settings and improve visual mark controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes are documented here.
 
+## [1.2.3] - 2026-08-14
+
+### Added
+
+- Added direct drag, pinch-to-resize, and two-finger rotation for visual signatures and stamps on a larger document preview.
+- Added a collapsed Manual position panel for precise position, size, and rotation adjustments.
+
+### Fixed
+
+- Settings now persist automatically after every change; Back, scanning, relaunching, and in-place updates no longer discard changes.
+- Fresh installs now delete saved PDFs after a sharing app is selected by default while keeping saved images.
+
 ## [1.2.2] - 2026-08-13
 
 ### Added
@@ -89,6 +101,7 @@ Historical copies retain the license supplied with them. See
 [1.1.0]: https://github.com/Majkey25/ScanIt/compare/v1.0.0...v1.1.0
 [1.2.0]: https://github.com/Majkey25/ScanIt/compare/v1.1.0...v1.2.0
 [1.2.2]: https://github.com/Majkey25/ScanIt/compare/v1.2.1...v1.2.2
+[1.2.3]: https://github.com/Majkey25/ScanIt/compare/v1.2.2...v1.2.3
 [1.2.1]: https://github.com/Majkey25/ScanIt/compare/v1.2.0...v1.2.1
 [1.1.0-alpha.1]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...main
 [1.2.0-beta.2]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...v1.2.0-beta.2

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.2.2"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt showing the Recent scans dashboard, visual signature editor, and custom PDF size settings."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.2.3"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt showing the Recent scans dashboard, visual signature editor, and custom PDF size settings."></a>
 </p>
 
-## v1.2.2 update
+## v1.2.3 update
 
 The current stable release keeps the full Google scan editor with page previews,
 crop and rotate, and Google's filter gallery, then continues directly to the
@@ -24,10 +24,13 @@ ScanIt Result and sharing actions. The redundant ScanIt intensity/shadow screen
 has been removed. The APK also includes the Recent scans dashboard, reusable
 visual signatures and stamps, measured and custom PDF size targets, and six
 selectable language modes. Settings now include a localized Buy Me a Coffee
-button; support remains optional and does not unlock features. ScanIt settings
-are retained during an in-place update.
+button; support remains optional and does not unlock features. Settings now save
+after each change, survive navigation and updates, and default to deleting saved
+PDFs after sharing while retaining saved images. Visual signatures and stamps
+can be moved directly on a larger preview, resized and rotated with gestures, or
+fine-tuned from the collapsed Manual position panel.
 
-[Download ScanIt v1.2.2](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.2)
+[Download ScanIt v1.2.3](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.3)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 35
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.2.2"
+        versionCode = 11
+        versionName = "1.2.3"
     }
 
     signingConfigs {

--- a/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
+++ b/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.2` on 2026-08-13. Its direct runtime dependencies are:
+`1.2.3` on 2026-08-13. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/app/src/main/java/com/majkeylab/scanit/AppUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/AppUi.kt
@@ -1085,6 +1085,32 @@ private fun SettingsScreen(
     val uriHandler = LocalUriHandler.current
     val supportNotice = stringResource(R.string.support_scanit_notice)
 
+    fun persistSettings() {
+        settingsError =
+            try {
+                val saved =
+                    onSave(
+                        AppSettings(
+                            savePdf = savePdf,
+                            saveImages = saveImages,
+                            albumName = albumName,
+                            multipage = multipage,
+                            allowGallery = allowGallery,
+                            emailSubject = emailSubject,
+                            emailBody = emailBody,
+                            pdfTreeUri = pdfTreeUri,
+                            deletePdfAfterShare = deletePdfAfterShare,
+                            deleteImagesAfterShare = deleteImagesAfterShare,
+                            appearance = settings.appearance,
+                            pdfSizeTarget = parsePdfSizeTarget(pdfSizeTargetWire),
+                        ),
+                    )
+                settingsSaveFailed.takeUnless { saved }
+            } catch (_: RuntimeException) {
+                settingsSaveFailed
+            }
+    }
+
     if (languageDialogOpen) {
         AlertDialog(
             onDismissRequest = { languageDialogOpen = false },
@@ -1143,6 +1169,7 @@ private fun SettingsScreen(
                     onClick = {
                         customMegabytes?.let { megabytes ->
                             pdfSizeTargetWire = PdfSizeTarget.Custom(megabytes).wireValue
+                            persistSettings()
                             customPdfSizeDialogOpen = false
                         }
                     },
@@ -1229,7 +1256,10 @@ private fun SettingsScreen(
                     items(PdfSizeTarget.presets) { target ->
                         FilterChip(
                             selected = target.wireValue == pdfSizeTargetWire,
-                            onClick = { pdfSizeTargetWire = target.wireValue },
+                            onClick = {
+                                pdfSizeTargetWire = target.wireValue
+                                persistSettings()
+                            },
                             label = { Text(pdfSizeTargetLabel(target)) },
                         )
                     }
@@ -1274,14 +1304,20 @@ private fun SettingsScreen(
                 SettingsSwitch(
                     label = stringResource(R.string.save_pdf),
                     checked = savePdf,
-                    onCheckedChange = { savePdf = it },
+                    onCheckedChange = {
+                        savePdf = it
+                        persistSettings()
+                    },
                 )
             }
             item {
                 SettingsSwitch(
                     label = stringResource(R.string.save_images),
                     checked = saveImages,
-                    onCheckedChange = { saveImages = it },
+                    onCheckedChange = {
+                        saveImages = it
+                        persistSettings()
+                    },
                 )
             }
             item {
@@ -1294,7 +1330,10 @@ private fun SettingsScreen(
             item {
                 OutlinedTextField(
                     value = albumName,
-                    onValueChange = { albumName = it },
+                    onValueChange = {
+                        albumName = it
+                        persistSettings()
+                    },
                     label = { Text(stringResource(R.string.album_name)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -1351,14 +1390,20 @@ private fun SettingsScreen(
                 SettingsSwitch(
                     label = stringResource(R.string.multiple_pages),
                     checked = multipage,
-                    onCheckedChange = { multipage = it },
+                    onCheckedChange = {
+                        multipage = it
+                        persistSettings()
+                    },
                 )
             }
             item {
                 SettingsSwitch(
                     label = stringResource(R.string.allow_gallery),
                     checked = allowGallery,
-                    onCheckedChange = { allowGallery = it },
+                    onCheckedChange = {
+                        allowGallery = it
+                        persistSettings()
+                    },
                 )
             }
             item { SectionTitle(stringResource(R.string.sharing)) }
@@ -1366,14 +1411,20 @@ private fun SettingsScreen(
                 SettingsSwitch(
                     label = stringResource(R.string.delete_pdf_after_share),
                     checked = deletePdfAfterShare,
-                    onCheckedChange = { deletePdfAfterShare = it },
+                    onCheckedChange = {
+                        deletePdfAfterShare = it
+                        persistSettings()
+                    },
                 )
             }
             item {
                 SettingsSwitch(
                     label = stringResource(R.string.delete_images_after_share),
                     checked = deleteImagesAfterShare,
-                    onCheckedChange = { deleteImagesAfterShare = it },
+                    onCheckedChange = {
+                        deleteImagesAfterShare = it
+                        persistSettings()
+                    },
                 )
             }
             item {
@@ -1386,7 +1437,10 @@ private fun SettingsScreen(
             item {
                 OutlinedTextField(
                     value = emailSubject,
-                    onValueChange = { emailSubject = it },
+                    onValueChange = {
+                        emailSubject = it
+                        persistSettings()
+                    },
                     label = { Text(stringResource(R.string.email_subject)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
@@ -1395,7 +1449,10 @@ private fun SettingsScreen(
             item {
                 OutlinedTextField(
                     value = emailBody,
-                    onValueChange = { emailBody = it },
+                    onValueChange = {
+                        emailBody = it
+                        persistSettings()
+                    },
                     label = { Text(stringResource(R.string.email_body)) },
                     minLines = 3,
                     modifier = Modifier.fillMaxWidth(),
@@ -1403,42 +1460,6 @@ private fun SettingsScreen(
             }
             item {
                 settingsError?.let { Text(it.resolve(), color = MaterialTheme.colorScheme.error) }
-                Button(
-                    onClick = {
-                        try {
-                            val saved =
-                                onSave(
-                                    AppSettings(
-                                        savePdf = savePdf,
-                                        saveImages = saveImages,
-                                        albumName = albumName,
-                                        multipage = multipage,
-                                        allowGallery = allowGallery,
-                                        emailSubject = emailSubject,
-                                        emailBody = emailBody,
-                                        pdfTreeUri = pdfTreeUri,
-                                        deletePdfAfterShare = deletePdfAfterShare,
-                                        deleteImagesAfterShare = deleteImagesAfterShare,
-                                        appearance = settings.appearance,
-                                        pdfSizeTarget = parsePdfSizeTarget(pdfSizeTargetWire),
-                                    ),
-                                )
-                            if (saved) {
-                                onClose()
-                            } else {
-                                settingsError = settingsSaveFailed
-                            }
-                        } catch (_: RuntimeException) {
-                            settingsError = settingsSaveFailed
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
-                ) {
-                    Text(stringResource(R.string.save_settings))
-                }
-                TextButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) {
-                    Text(stringResource(R.string.cancel))
-                }
                 TextButton(
                     onClick = { uriHandler.openUri(PRIVACY_POLICY_URL) },
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/majkeylab/scanit/MarkModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/MarkModels.kt
@@ -1,5 +1,10 @@
 package com.majkeylab.scanit
 
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
 internal const val MAX_MARK_TEMPLATES = 12
 internal const val MAX_MARK_INPUT_BYTES = 20_000_000L
 internal const val MARK_DECODE_MAX_SIDE = 2_048
@@ -37,6 +42,7 @@ internal data class MarkPlacement(
     val centerX: Float = 0.5f,
     val centerY: Float = 0.75f,
     val widthFraction: Float = 0.35f,
+    val rotationDegrees: Float = 0f,
 ) {
     init {
         require(centerX.isFinite() && centerX in 0f..1f) { "Mark horizontal position is invalid" }
@@ -46,6 +52,9 @@ internal data class MarkPlacement(
                 widthFraction in MIN_MARK_WIDTH_FRACTION..MAX_MARK_WIDTH_FRACTION,
         ) {
             "Mark width is invalid"
+        }
+        require(rotationDegrees.isFinite() && rotationDegrees in -180f..180f) {
+            "Mark rotation is invalid"
         }
     }
 }
@@ -130,12 +139,19 @@ internal fun resolveMarkRect(
         height = pageHeightDouble
         width = height / aspect
     }
-    val left =
-        (pageWidthDouble * placement.centerX - width / 2.0)
-            .coerceIn(0.0, pageWidthDouble - width)
-    val top =
-        (pageHeightDouble * placement.centerY - height / 2.0)
-            .coerceIn(0.0, pageHeightDouble - height)
+    var rotated = rotatedMarkSize(width, height, placement.rotationDegrees)
+    val scaleDown = min(1.0, min(pageWidthDouble / rotated.first, pageHeightDouble / rotated.second))
+    width *= scaleDown
+    height *= scaleDown
+    rotated = rotatedMarkSize(width, height, placement.rotationDegrees)
+    val centerX =
+        (pageWidthDouble * placement.centerX)
+            .coerceIn(rotated.first / 2.0, pageWidthDouble - rotated.first / 2.0)
+    val centerY =
+        (pageHeightDouble * placement.centerY)
+            .coerceIn(rotated.second / 2.0, pageHeightDouble - rotated.second / 2.0)
+    val left = centerX - width / 2.0
+    val top = centerY - height / 2.0
     return MarkRect(
         left = left.toFloat(),
         top = top.toFloat(),
@@ -155,13 +171,65 @@ internal fun dragMarkPlacement(
 ): MarkPlacement {
     require(deltaX.isFinite() && deltaY.isFinite()) { "Mark drag must be finite" }
     val rect = resolveMarkRect(pageWidth, pageHeight, markWidth, markHeight, placement)
+    val rotated =
+        rotatedMarkSize(rect.width.toDouble(), rect.height.toDouble(), placement.rotationDegrees)
     val centerX =
         ((rect.left + rect.right) / 2f + deltaX)
-            .coerceIn(rect.width / 2f, pageWidth - rect.width / 2f)
+            .coerceIn((rotated.first / 2.0).toFloat(), pageWidth - (rotated.first / 2.0).toFloat())
     val centerY =
         ((rect.top + rect.bottom) / 2f + deltaY)
-            .coerceIn(rect.height / 2f, pageHeight - rect.height / 2f)
+            .coerceIn((rotated.second / 2.0).toFloat(), pageHeight - (rotated.second / 2.0).toFloat())
     return placement.copy(centerX = centerX / pageWidth, centerY = centerY / pageHeight)
+}
+
+internal fun transformMarkPlacement(
+    pageWidth: Float,
+    pageHeight: Float,
+    markWidth: Int,
+    markHeight: Int,
+    placement: MarkPlacement,
+    panX: Float,
+    panY: Float,
+    zoom: Float,
+    rotationDegrees: Float,
+): MarkPlacement {
+    require(panX.isFinite() && panY.isFinite()) { "Mark pan must be finite" }
+    require(zoom.isFinite() && zoom > 0f) { "Mark zoom must be positive and finite" }
+    require(rotationDegrees.isFinite()) { "Mark rotation delta must be finite" }
+    val resized =
+        placement.copy(
+            widthFraction =
+                (placement.widthFraction * zoom)
+                    .coerceIn(MIN_MARK_WIDTH_FRACTION, MAX_MARK_WIDTH_FRACTION),
+            rotationDegrees = normalizeMarkRotation(placement.rotationDegrees + rotationDegrees),
+        )
+    return dragMarkPlacement(
+        pageWidth = pageWidth,
+        pageHeight = pageHeight,
+        markWidth = markWidth,
+        markHeight = markHeight,
+        placement = resized,
+        deltaX = panX,
+        deltaY = panY,
+    )
+}
+
+private fun rotatedMarkSize(
+    width: Double,
+    height: Double,
+    rotationDegrees: Float,
+): Pair<Double, Double> {
+    val radians = Math.toRadians(rotationDegrees.toDouble())
+    val cosine = abs(cos(radians))
+    val sine = abs(sin(radians))
+    return width * cosine + height * sine to width * sine + height * cosine
+}
+
+private fun normalizeMarkRotation(value: Float): Float {
+    var normalized = value % 360f
+    if (normalized > 180f) normalized -= 360f
+    if (normalized < -180f) normalized += 360f
+    return if (normalized == -0f) 0f else normalized
 }
 
 internal fun scaleNormalizedMarkStrokes(

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -21,7 +21,7 @@ internal data class AppSettings(
     val emailSubject: String = "Scanned document",
     val emailBody: String = "",
     val pdfTreeUri: String? = null,
-    val deletePdfAfterShare: Boolean = false,
+    val deletePdfAfterShare: Boolean = true,
     val deleteImagesAfterShare: Boolean = false,
     val appearance: ScanAppearanceSettings = ScanAppearanceSettings(),
     val pdfSizeTarget: PdfSizeTarget = PdfSizeTarget.Original,

--- a/app/src/main/java/com/majkeylab/scanit/VisualMarkRendering.kt
+++ b/app/src/main/java/com/majkeylab/scanit/VisualMarkRendering.kt
@@ -63,13 +63,24 @@ internal fun renderMarkedSourceJpeg(
                     markWidth = mark.width,
                     markHeight = mark.height,
                     placement = placement,
-                )
-            Canvas(page).drawBitmap(
-                mark,
-                null,
-                RectF(rect.left, rect.top, rect.right, rect.bottom),
-                Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG),
             )
+            val canvas = Canvas(page)
+            val saveCount = canvas.save()
+            try {
+                canvas.rotate(
+                    placement.rotationDegrees,
+                    (rect.left + rect.right) / 2f,
+                    (rect.top + rect.bottom) / 2f,
+                )
+                canvas.drawBitmap(
+                    mark,
+                    null,
+                    RectF(rect.left, rect.top, rect.right, rect.bottom),
+                    Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG),
+                )
+            } finally {
+                canvas.restoreToCount(saveCount)
+            }
         },
         isCancelled = isCancelled,
     )

--- a/app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt
@@ -14,9 +14,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateRotation
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -75,7 +76,6 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
@@ -121,6 +121,10 @@ internal fun VisualMarkEditorScreen(
     val source = editor.source
     if (source.pageIndex !in result.scan.cached.pages.indices) return
     var showDeleteConfirmation by
+        rememberSaveable(source.cacheId, source.entryId, source.pageIndex) {
+            mutableStateOf(false)
+        }
+    var manualPositionExpanded by
         rememberSaveable(source.cacheId, source.entryId, source.pageIndex) {
             mutableStateOf(false)
         }
@@ -191,24 +195,50 @@ internal fun VisualMarkEditorScreen(
                 }
             }
             item {
-                VisualMarkSlider(
-                    stringResource(R.string.horizontal_position),
-                    editor.placement.centerX,
-                    selectedBitmap != null && !editor.busy,
-                    0f..1f,
-                ) { onPlacementChange(editor.placement.copy(centerX = it)) }
-                VisualMarkSlider(
-                    stringResource(R.string.vertical_position),
-                    editor.placement.centerY,
-                    selectedBitmap != null && !editor.busy,
-                    0f..1f,
-                ) { onPlacementChange(editor.placement.copy(centerY = it)) }
-                VisualMarkSlider(
-                    stringResource(R.string.visual_mark_size),
-                    editor.placement.widthFraction,
-                    selectedBitmap != null && !editor.busy,
-                    MIN_MARK_WIDTH_FRACTION..MAX_MARK_WIDTH_FRACTION,
-                ) { onPlacementChange(editor.placement.copy(widthFraction = it)) }
+                OutlinedButton(
+                    onClick = { manualPositionExpanded = !manualPositionExpanded },
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(stringResource(R.string.manual_position))
+                        Icon(
+                            painterResource(R.drawable.ic_expand_more),
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+                if (manualPositionExpanded) {
+                    VisualMarkSlider(
+                        stringResource(R.string.horizontal_position),
+                        editor.placement.centerX,
+                        selectedBitmap != null && !editor.busy,
+                        0f..1f,
+                    ) { onPlacementChange(editor.placement.copy(centerX = it)) }
+                    VisualMarkSlider(
+                        stringResource(R.string.vertical_position),
+                        editor.placement.centerY,
+                        selectedBitmap != null && !editor.busy,
+                        0f..1f,
+                    ) { onPlacementChange(editor.placement.copy(centerY = it)) }
+                    VisualMarkSlider(
+                        stringResource(R.string.visual_mark_size),
+                        editor.placement.widthFraction,
+                        selectedBitmap != null && !editor.busy,
+                        MIN_MARK_WIDTH_FRACTION..MAX_MARK_WIDTH_FRACTION,
+                    ) { onPlacementChange(editor.placement.copy(widthFraction = it)) }
+                    VisualMarkSlider(
+                        stringResource(R.string.visual_mark_rotation),
+                        editor.placement.rotationDegrees,
+                        selectedBitmap != null && !editor.busy,
+                        -180f..180f,
+                        asDegrees = true,
+                    ) { onPlacementChange(editor.placement.copy(rotationDegrees = it)) }
+                }
             }
             editor.message?.takeIf { editor.drawingStrokes == null }?.let { message ->
                 item {
@@ -427,7 +457,7 @@ private fun VisualMarkPreview(
     val currentOnPlacementChange by rememberUpdatedState(onPlacementChange)
     Canvas(
         modifier =
-            Modifier.fillMaxWidth().height(300.dp)
+            Modifier.fillMaxWidth().height(420.dp)
                 .background(MaterialTheme.colorScheme.surfaceVariant)
                 .pointerInput(page, mark, enabled) {
                     val pageBitmap = page ?: return@pointerInput
@@ -440,56 +470,31 @@ private fun VisualMarkPreview(
                         )
                     val pageWidth = pageBitmap.width * scale
                     val pageHeight = pageBitmap.height * scale
-                    val left = (size.width - pageWidth) / 2f
-                    val top = (size.height - pageHeight) / 2f
                     awaitEachGesture {
-                        val down = awaitFirstDown(requireUnconsumed = false)
-                        val initialPlacement = currentPlacement
-                        val rect =
-                            resolveMarkRect(
-                                pageWidth,
-                                pageHeight,
-                                markBitmap.width,
-                                markBitmap.height,
-                                initialPlacement,
-                            )
-                        if (
-                            down.position.x !in (left + rect.left)..(left + rect.right) ||
-                            down.position.y !in (top + rect.top)..(top + rect.bottom)
-                        ) {
-                            return@awaitEachGesture
-                        }
-                        var dragPlacement = initialPlacement
-                        val dragStart =
-                            awaitTouchSlopOrCancellation(down.id) { change, overSlop ->
-                                change.consume()
-                                dragPlacement =
-                                    dragMarkPlacement(
-                                        pageWidth,
-                                        pageHeight,
-                                        markBitmap.width,
-                                        markBitmap.height,
-                                        dragPlacement,
-                                        overSlop.x,
-                                        overSlop.y,
+                        awaitFirstDown(requireUnconsumed = false)
+                        var gesturePlacement = currentPlacement
+                        do {
+                            val event = awaitPointerEvent()
+                            val pan = event.calculatePan()
+                            val zoom = event.calculateZoom()
+                            val rotation = event.calculateRotation()
+                            if (pan != Offset.Zero || zoom != 1f || rotation != 0f) {
+                                gesturePlacement =
+                                    transformMarkPlacement(
+                                        pageWidth = pageWidth,
+                                        pageHeight = pageHeight,
+                                        markWidth = markBitmap.width,
+                                        markHeight = markBitmap.height,
+                                        placement = gesturePlacement,
+                                        panX = pan.x,
+                                        panY = pan.y,
+                                        zoom = zoom,
+                                        rotationDegrees = rotation,
                                     )
-                                currentOnPlacementChange(dragPlacement)
-                            } ?: return@awaitEachGesture
-                        drag(dragStart.id) { change ->
-                            val dragAmount = change.positionChange()
-                            change.consume()
-                            dragPlacement =
-                                dragMarkPlacement(
-                                    pageWidth = pageWidth,
-                                    pageHeight = pageHeight,
-                                    markWidth = markBitmap.width,
-                                    markHeight = markBitmap.height,
-                                    placement = dragPlacement,
-                                    deltaX = dragAmount.x,
-                                    deltaY = dragAmount.y,
-                                )
-                            currentOnPlacementChange(dragPlacement)
-                        }
+                                event.changes.forEach { it.consume() }
+                                currentOnPlacementChange(gesturePlacement)
+                            }
+                        } while (event.changes.any { it.pressed })
                     }
                 }
                 .semantics { contentDescription = description },
@@ -508,12 +513,23 @@ private fun VisualMarkPreview(
         )
         mark?.let {
             val rect = resolveMarkRect(pageWidth, pageHeight, it.width, it.height, placement)
-            drawContext.canvas.nativeCanvas.drawBitmap(
-                it,
-                null,
-                RectF(left + rect.left, top + rect.top, left + rect.right, top + rect.bottom),
-                paint,
-            )
+            val canvas = drawContext.canvas.nativeCanvas
+            val saveCount = canvas.save()
+            try {
+                canvas.rotate(
+                    placement.rotationDegrees,
+                    left + (rect.left + rect.right) / 2f,
+                    top + (rect.top + rect.bottom) / 2f,
+                )
+                canvas.drawBitmap(
+                    it,
+                    null,
+                    RectF(left + rect.left, top + rect.top, left + rect.right, top + rect.bottom),
+                    paint,
+                )
+            } finally {
+                canvas.restoreToCount(saveCount)
+            }
         }
     }
 }
@@ -524,10 +540,16 @@ private fun VisualMarkSlider(
     value: Float,
     enabled: Boolean,
     valueRange: ClosedFloatingPointRange<Float>,
+    asDegrees: Boolean = false,
     onValueChange: (Float) -> Unit,
 ) {
-    val percent = stringResource(R.string.visual_mark_percent, (value * 100).roundToInt())
-    Text(stringResource(R.string.visual_mark_slider_value, label, percent))
+    val displayedValue =
+        if (asDegrees) {
+            stringResource(R.string.visual_mark_degrees, value.roundToInt())
+        } else {
+            stringResource(R.string.visual_mark_percent, (value * 100).roundToInt())
+        }
+    Text(stringResource(R.string.visual_mark_slider_value, label, displayedValue))
     Slider(
         value = value,
         onValueChange = onValueChange,
@@ -535,7 +557,7 @@ private fun VisualMarkSlider(
         valueRange = valueRange,
         modifier = Modifier.fillMaxWidth().semantics {
             contentDescription = label
-            stateDescription = percent
+            stateDescription = displayedValue
         },
     )
 }

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -164,6 +164,8 @@
     <string name="horizontal_position">Vodorovná poloha</string>
     <string name="vertical_position">Svislá poloha</string>
     <string name="visual_mark_size">Velikost</string>
+    <string name="visual_mark_rotation">Otočení</string>
+    <string name="manual_position">Ruční umístění</string>
     <string name="apply_visual_mark">Použít na stránku %1$d</string>
     <string name="visual_mark_working">Pracuji…</string>
     <string name="draw_visual_mark_title">Nakreslit podpis nebo razítko</string>
@@ -176,8 +178,9 @@
     <string name="delete_visual_mark_body">Tímto odstraníte vybraný uložený podpis nebo razítko.</string>
     <string name="delete_visual_mark_confirm">Smazat</string>
     <string name="visual_mark_preview">Náhled podpisu nebo razítka</string>
-    <string name="drag_visual_mark_hint">Přetažením podpis umístěte.</string>
+    <string name="drag_visual_mark_hint">Přetažením podpis posuňte. Sevřením prstů změňte velikost a otočte ho.</string>
     <string name="saved_visual_mark_number">Uložená značka %1$d</string>
     <string name="visual_mark_percent">%1$d %%</string>
+    <string name="visual_mark_degrees">%1$d°</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -160,6 +160,8 @@
     <string name="horizontal_position">Horizontale Position</string>
     <string name="vertical_position">Vertikale Position</string>
     <string name="visual_mark_size">Größe</string>
+    <string name="visual_mark_rotation">Drehung</string>
+    <string name="manual_position">Manuelle Position</string>
     <string name="apply_visual_mark">Auf Seite %1$d anwenden</string>
     <string name="visual_mark_working">Verarbeitung…</string>
     <string name="draw_visual_mark_title">Unterschrift oder Stempel zeichnen</string>
@@ -172,8 +174,9 @@
     <string name="delete_visual_mark_body">Die ausgewählte gespeicherte Unterschrift oder der Stempel wird entfernt.</string>
     <string name="delete_visual_mark_confirm">Löschen</string>
     <string name="visual_mark_preview">Vorschau der Unterschrift oder des Stempels</string>
-    <string name="drag_visual_mark_hint">Unterschrift ziehen, um sie zu platzieren.</string>
+    <string name="drag_visual_mark_hint">Zum Verschieben ziehen. Zum Skalieren und Drehen zwei Finger verwenden.</string>
     <string name="saved_visual_mark_number">Gespeicherte Markierung %1$d</string>
     <string name="visual_mark_percent">%1$d%%</string>
+    <string name="visual_mark_degrees">%1$d°</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -161,6 +161,8 @@
     <string name="horizontal_position">Posición horizontal</string>
     <string name="vertical_position">Posición vertical</string>
     <string name="visual_mark_size">Tamaño</string>
+    <string name="visual_mark_rotation">Rotación</string>
+    <string name="manual_position">Posición manual</string>
     <string name="apply_visual_mark">Aplicar a la página %1$d</string>
     <string name="visual_mark_working">Procesando…</string>
     <string name="draw_visual_mark_title">Dibujar firma o sello</string>
@@ -173,8 +175,9 @@
     <string name="delete_visual_mark_body">Esto elimina la firma o el sello guardado seleccionado.</string>
     <string name="delete_visual_mark_confirm">Eliminar</string>
     <string name="visual_mark_preview">Vista previa de la firma o el sello</string>
-    <string name="drag_visual_mark_hint">Arrastra la firma para colocarla.</string>
+    <string name="drag_visual_mark_hint">Arrastra para mover. Pellizca para cambiar el tamaño y girar.</string>
     <string name="saved_visual_mark_number">Marca guardada %1$d</string>
     <string name="visual_mark_percent">%1$d%%</string>
+    <string name="visual_mark_degrees">%1$d°</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -159,6 +159,8 @@
     <string name="horizontal_position">水平位置</string>
     <string name="vertical_position">垂直位置</string>
     <string name="visual_mark_size">大小</string>
+    <string name="visual_mark_rotation">旋转</string>
+    <string name="manual_position">手动定位</string>
     <string name="apply_visual_mark">应用到第 %1$d 页</string>
     <string name="visual_mark_working">正在处理…</string>
     <string name="draw_visual_mark_title">绘制签名或印章</string>
@@ -171,8 +173,9 @@
     <string name="delete_visual_mark_body">这会删除所选的已保存签名或印章。</string>
     <string name="delete_visual_mark_confirm">删除</string>
     <string name="visual_mark_preview">签名或印章预览</string>
-    <string name="drag_visual_mark_hint">拖动签名以放置。</string>
+    <string name="drag_visual_mark_hint">拖动以移动。双指捏合可调整大小并旋转。</string>
     <string name="saved_visual_mark_number">已保存标记 %1$d</string>
     <string name="visual_mark_percent">%1$d%%</string>
+    <string name="visual_mark_degrees">%1$d°</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="horizontal_position">Horizontal position</string>
     <string name="vertical_position">Vertical position</string>
     <string name="visual_mark_size">Size</string>
+    <string name="visual_mark_rotation">Rotation</string>
+    <string name="manual_position">Manual position</string>
     <string name="apply_visual_mark">Apply to page %1$d</string>
     <string name="visual_mark_working">Working…</string>
     <string name="draw_visual_mark_title">Draw signature or stamp</string>
@@ -174,8 +176,9 @@
     <string name="delete_visual_mark_body">This removes the selected saved signature or stamp.</string>
     <string name="delete_visual_mark_confirm">Delete</string>
     <string name="visual_mark_preview">Signature or stamp preview</string>
-    <string name="drag_visual_mark_hint">Drag the signature to place it.</string>
+    <string name="drag_visual_mark_hint">Drag to move. Pinch to resize and rotate.</string>
     <string name="saved_visual_mark_number">Saved mark %1$d</string>
     <string name="visual_mark_percent">%1$d%%</string>
+    <string name="visual_mark_degrees">%1$d°</string>
     <string name="visual_mark_slider_value">%1$s · %2$s</string>
 </resources>

--- a/app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt
@@ -97,6 +97,83 @@ class MarkLogicTest {
     }
 
     @Test
+    fun markTransformCombinesPanZoomAndNormalizedRotation() {
+        val transformed =
+            transformMarkPlacement(
+                pageWidth = 1_000f,
+                pageHeight = 2_000f,
+                markWidth = 400,
+                markHeight = 200,
+                placement = MarkPlacement(centerX = 0.5f, centerY = 0.5f, rotationDegrees = 170f),
+                panX = 100f,
+                panY = -200f,
+                zoom = 2f,
+                rotationDegrees = 30f,
+            )
+
+        assertEquals(0.6f, transformed.centerX, 0.0001f)
+        assertEquals(0.4f, transformed.centerY, 0.0001f)
+        assertEquals(0.7f, transformed.widthFraction, 0.0001f)
+        assertEquals(-160f, transformed.rotationDegrees, 0.0001f)
+    }
+
+    @Test
+    fun markTransformClampsZoomAndRotatedBounds() {
+        val minimum =
+            transformMarkPlacement(
+                1_000f,
+                2_000f,
+                400,
+                200,
+                MarkPlacement(widthFraction = MIN_MARK_WIDTH_FRACTION),
+                0f,
+                0f,
+                0.1f,
+                0f,
+            )
+        val maximum =
+            transformMarkPlacement(
+                1_000f,
+                2_000f,
+                400,
+                200,
+                MarkPlacement(centerX = 0f, centerY = 0f, widthFraction = MAX_MARK_WIDTH_FRACTION),
+                0f,
+                0f,
+                2f,
+                90f,
+            )
+
+        assertEquals(MIN_MARK_WIDTH_FRACTION, minimum.widthFraction, 0f)
+        assertEquals(MAX_MARK_WIDTH_FRACTION, maximum.widthFraction, 0f)
+        assertEquals(0.2f, maximum.centerX, 0.0001f)
+        assertEquals(0.2f, maximum.centerY, 0.0001f)
+    }
+
+    @Test
+    fun markTransformRejectsMalformedGestureValues() {
+        assertThrows(IllegalArgumentException::class.java) {
+            transformMarkPlacement(1_000f, 2_000f, 400, 200, MarkPlacement(), 0f, 0f, 0f, 0f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            transformMarkPlacement(
+                1_000f,
+                2_000f,
+                400,
+                200,
+                MarkPlacement(),
+                Float.NaN,
+                0f,
+                1f,
+                0f,
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            MarkPlacement(rotationDegrees = Float.NaN)
+        }
+    }
+
+    @Test
     fun tallMarkScalesDownWithoutChangingAspect() {
         val rect =
             resolveMarkRect(

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -52,7 +52,7 @@ class PureLogicTest {
                 emailSubject = "Scanned document",
                 emailBody = "",
                 pdfTreeUri = null,
-                deletePdfAfterShare = false,
+                deletePdfAfterShare = true,
                 deleteImagesAfterShare = false,
                 appearance = ScanAppearanceSettings(),
                 pdfSizeTarget = PdfSizeTarget.Original,
@@ -144,8 +144,27 @@ class PureLogicTest {
         values["delete_pdf_after_share"] = "wrong"
         values["delete_images_after_share"] = 1
 
-        assertFalse(store.load().deletePdfAfterShare)
+        assertTrue(store.load().deletePdfAfterShare)
         assertFalse(store.load().deleteImagesAfterShare)
+    }
+
+    @Test
+    fun explicitDeleteAfterShareChoicesSurviveStoreRecreation() {
+        val (preferences, _) = inMemoryPreferences()
+        val first = SettingsStore(preferences, "Scanned document")
+        val owner = first.authoritySnapshot().owner
+
+        assertEquals(
+            AuthorityMutationResult.Applied,
+            first.trySave(
+                AppSettings(deletePdfAfterShare = false, deleteImagesAfterShare = true),
+                owner,
+            ),
+        )
+
+        val restored = SettingsStore(preferences, "Scanned document").load()
+        assertFalse(restored.deletePdfAfterShare)
+        assertTrue(restored.deleteImagesAfterShare)
     }
 
     @Test

--- a/docs/superpowers/plans/2026-08-13-settings-and-mark-gestures.md
+++ b/docs/superpowers/plans/2026-08-13-settings-and-mark-gestures.md
@@ -1,0 +1,169 @@
+# Settings Persistence and Visual Mark Gestures Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every Settings change immediately and add direct move, resize, and rotation gestures to visual marks.
+
+**Architecture:** Settings keeps a local Compose draft for responsive controls, but every mutation sends the complete draft through the existing `ScanViewModel.saveSettings` authority boundary. Visual mark gestures update the existing `MarkPlacement` state; preview and final JPEG rendering consume the same validated rotation-aware geometry.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Android Canvas, SharedPreferences, JUnit 4, Gradle.
+
+## Global Constraints
+
+- Existing explicit settings must survive app updates.
+- Fresh installs default to delete saved PDF after sharing ON and images OFF.
+- No new runtime dependency.
+- Keep all sliders collapsed under `Manual position`.
+- Ads and premium are excluded from this stable release.
+
+---
+
+### Task 1: Automatic Settings Persistence
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/ScanModels.kt`
+- Modify: `app/src/main/java/com/majkeylab/scanit/AppUi.kt`
+- Test: `app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt`
+
+**Interfaces:**
+- Consumes: `SettingsStore.trySave(AppSettings, ActiveResultOwner)` through `ScanViewModel.saveSettings`.
+- Produces: `AppSettings.deletePdfAfterShare = true` default and immediate full-draft saves.
+
+- [ ] **Step 1: Write failing default and recreation tests**
+
+Assert `AppSettings().deletePdfAfterShare` is true, images is false, malformed preferences use those defaults, and explicit false/true values survive a new `SettingsStore` instance.
+
+- [ ] **Step 2: Run RED**
+
+Run: `.\gradlew.bat :app:testInternalDebugUnitTest --tests com.majkeylab.scanit.PureLogicTest --no-daemon --console=plain`
+
+Expected: the fresh and malformed PDF default assertions fail against the old false default.
+
+- [ ] **Step 3: Implement immediate persistence**
+
+Set only the model default:
+
+```kotlin
+val deletePdfAfterShare: Boolean = true
+val deleteImagesAfterShare: Boolean = false
+```
+
+In `SettingsScreen`, build the current `AppSettings` draft in one local `persistSettings()` function. Every switch, text field, PDF target, and custom target mutation updates local state and then calls it. Keep folder and language persistence on their existing dedicated boundaries. Remove `Save settings` and `Cancel`.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the focused test and `:app:compileInternalDebugKotlin`.
+
+### Task 2: Rotation-Aware Mark Geometry
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/MarkModels.kt`
+- Test: `app/src/test/java/com/majkeylab/scanit/MarkLogicTest.kt`
+
+**Interfaces:**
+- Produces: `MarkPlacement.rotationDegrees: Float` and `transformMarkPlacement(...): MarkPlacement`.
+
+- [ ] **Step 1: Write failing geometry tests**
+
+Cover a 2x zoom, minimum/maximum zoom clamp, pan, +45 degree rotation, wrap past 180 degrees, a rotated edge placement, and rejection of NaN/zero zoom.
+
+- [ ] **Step 2: Run RED**
+
+Run: `.\gradlew.bat :app:testInternalDebugUnitTest --tests com.majkeylab.scanit.MarkLogicTest --no-daemon --console=plain`
+
+Expected: compilation fails because rotation and transform APIs do not exist.
+
+- [ ] **Step 3: Implement validated geometry**
+
+Add a finite normalized rotation to `MarkPlacement`. Compute the rotated bounding width/height from sine/cosine, clamp its center inside the page, and implement:
+
+```kotlin
+internal fun transformMarkPlacement(
+    pageWidth: Float,
+    pageHeight: Float,
+    markWidth: Int,
+    markHeight: Int,
+    placement: MarkPlacement,
+    panX: Float,
+    panY: Float,
+    zoom: Float,
+    rotationDegrees: Float,
+): MarkPlacement
+```
+
+Clamp width to `MIN_MARK_WIDTH_FRACTION..MAX_MARK_WIDTH_FRACTION`, normalize rotation, then apply the pan using the new rotated geometry.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the focused MarkLogic test.
+
+### Task 3: Direct Gestures and Collapsed Manual Controls
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/VisualMarkUi.kt`
+- Modify: `app/src/main/res/values/strings.xml`
+- Modify: `app/src/main/res/values-cs/strings.xml`
+- Modify: `app/src/main/res/values-de/strings.xml`
+- Modify: `app/src/main/res/values-es/strings.xml`
+- Modify: `app/src/main/res/values-zh-rCN/strings.xml`
+
+**Interfaces:**
+- Consumes: `transformMarkPlacement` and `onPlacementChange`.
+- Produces: direct pan/pinch/rotation input and a collapsed precise-control section.
+
+- [ ] **Step 1: Replace drag-only input**
+
+Use Compose `detectTransformGestures` on the enlarged preview. Send pan, zoom, and rotation through `transformMarkPlacement`. Disable input while busy or without a selected mark.
+
+- [ ] **Step 2: Render preview rotation**
+
+Save the native canvas, rotate around the resolved mark rectangle center, draw the bitmap, and restore the canvas.
+
+- [ ] **Step 3: Collapse precise controls**
+
+Add a `rememberSaveable` boolean and full-width `Manual position` button with `ic_expand_more`. Show X, Y, size, and rotation sliders only when expanded.
+
+- [ ] **Step 4: Localize copy**
+
+Add localized `manual_position`, `visual_mark_rotation`, and move/pinch/rotate hint strings for EN/CS/DE/ES/ZH.
+
+### Task 4: Final Output Rotation
+
+**Files:**
+- Modify: `app/src/main/java/com/majkeylab/scanit/VisualMarkRendering.kt`
+
+**Interfaces:**
+- Consumes: `MarkPlacement.rotationDegrees`.
+- Produces: a JPEG whose mark transform matches the preview.
+
+- [ ] **Step 1: Apply rotation during render**
+
+Rotate Android `Canvas` around `RectF.centerX()/centerY()`, draw the mark, and restore inside the existing `transformBitmap` callback.
+
+- [ ] **Step 2: Run full host gate**
+
+Run: `.\gradlew.bat clean :app:testInternalDebugUnitTest :app:lintInternalDebug :app:assembleInternalDebug --no-daemon --console=plain`
+
+Expected: BUILD SUCCESSFUL, no test/lint errors.
+
+### Task 5: Emulator, Release, and Play Alpha
+
+**Files:**
+- Modify: `app/build.gradle.kts`
+- Modify release notes/version files already used by the repository.
+
+- [ ] **Step 1: Upgrade QA**
+
+Install the prior internal APK, set explicit delete choices, then update without uninstalling. Verify the explicit values remain. Clear app data and verify fresh PDF ON/images OFF. Toggle both, Back, reopen Settings, scan/cancel, force-stop/relaunch, and verify values each time.
+
+- [ ] **Step 2: Gesture QA**
+
+Create/select a visual mark; drag, pinch smaller/larger, rotate, use `Manual position`, Apply, reopen the derived result, and inspect the generated page. Verify busy/Back and no crash buffer entries.
+
+- [ ] **Step 3: Release verification**
+
+Bump to version code 11/name 1.2.3, build signed Play AAB and GitHub artifacts using `tools/build.ps1`, run the repository artifact verifier, and record SHA-256 values.
+
+- [ ] **Step 4: Publish**
+
+Commit, push, merge only after green CI, create GitHub `v1.2.3`, upload the exact Play AAB to Closed testing Alpha, and submit the change for Google review. Do not install a separate phone package because the user will update through Play Early Access.

--- a/docs/superpowers/specs/2026-08-13-visual-mark-gestures-design.md
+++ b/docs/superpowers/specs/2026-08-13-visual-mark-gestures-design.md
@@ -1,0 +1,35 @@
+# Visual mark gesture controls
+
+## Goal
+
+Make signature placement direct and preview-first. The user manipulates the selected visual mark on the scanned page instead of depending on always-visible sliders.
+
+## Considered approaches
+
+1. Direct transform gestures + collapsed precise controls. Recommended. One finger moves the mark; two fingers resize and rotate it. Existing sliders remain available under `Manual position` for accessibility and exact adjustment.
+2. Visible resize/rotation handles. Discoverable, but adds small targets and visual clutter over the document.
+3. Sliders only. Simple implementation, but it is the current inconvenient workflow and leaves too little room for the page preview.
+
+## UI
+
+- Increase the document preview height.
+- Keep direct one-finger drag.
+- Add two-finger pinch to resize within the existing 10–80% width limits.
+- Add two-finger rotation around the signature center.
+- Update the hint to explain move, pinch, and rotate.
+- Put horizontal position, vertical position, size, and rotation sliders in a collapsed `Manual position` section.
+- Keep template creation, selection, deletion, disclaimer, and Apply behavior unchanged.
+
+## State and rendering
+
+`MarkPlacement` gains a finite normalized rotation in degrees. Gesture deltas produce one validated placement update. Preview rendering and final JPEG rendering use the same center, size, and rotation. Placement remains bounded to the page as far as the rotated signature geometry permits.
+
+## Failure and accessibility
+
+Gestures are disabled while the editor is busy or no template is selected. Invalid or non-finite gesture input is rejected. The collapsed sliders provide a non-gesture path and expose semantic labels and values.
+
+## Verification
+
+- Unit tests: pan, zoom clamp, rotation normalization, malformed values, and edge bounds.
+- Build/lint/unit gate.
+- Emulator: drag, pinch smaller/larger, rotate, expand precise controls, apply, reopen generated PDF, and confirm Back/cancel behavior.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -18,7 +18,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "10"
+$expectedVersionCode = "11"
 $expectedMinSdk = "35"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -27,15 +27,15 @@ $sdkRootWasExplicit = $PSBoundParameters.ContainsKey("SdkRoot")
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.2.2-internal"
+        $expectedVersionName = "1.2.3-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.2.2"
+        $expectedVersionName = "1.2.3"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.2.2"
+        $expectedVersionName = "1.2.3"
     }
 }
 


### PR DESCRIPTION
## Summary
- save every settings change automatically; remove Save/Cancel actions
- default fresh installs to delete saved PDFs after sharing while retaining images
- add direct drag, pinch resize, and rotation for visual marks with a larger preview
- prepare version 1.2.3 release metadata

## Verification
- full local release gate: tools/build.ps1 PASS
- internal unit tests + lint + internal/play/GitHub release artifacts verified
- emulator: fresh defaults, upgrade preservation, Back/reopen, scan/relaunch, direct drag, manual resize/rotation, final rendered mark
- no app crashes in filtered logcat