### PR TITLE
feat: support Android 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here.
 
+## [1.2.4] - 2026-08-14
+
+### Changed
+
+- Expanded support to Android 13 and newer (`minSdk 33`).
+- Kept delete-after-sharing callbacks safe on Android 13 and 14 by using the legacy selected-component result while retaining the richer Android 15+ chooser result.
+
 ## [1.2.3] - 2026-08-14
 
 ### Added
@@ -102,6 +109,7 @@ Historical copies retain the license supplied with them. See
 [1.2.0]: https://github.com/Majkey25/ScanIt/compare/v1.1.0...v1.2.0
 [1.2.2]: https://github.com/Majkey25/ScanIt/compare/v1.2.1...v1.2.2
 [1.2.3]: https://github.com/Majkey25/ScanIt/compare/v1.2.2...v1.2.3
+[1.2.4]: https://github.com/Majkey25/ScanIt/compare/v1.2.3...v1.2.4
 [1.2.1]: https://github.com/Majkey25/ScanIt/compare/v1.2.0...v1.2.1
 [1.1.0-alpha.1]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...main
 [1.2.0-beta.2]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...v1.2.0-beta.2

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 <p align="center">
   <a href="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml"><img alt="Android CI" src="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml/badge.svg"></a>
   <a href="https://github.com/Majkey25/ScanIt/releases/latest"><img alt="Latest stable release" src="https://img.shields.io/github/v/release/Majkey25/ScanIt"></a>
-  <img alt="Android 15+" src="https://img.shields.io/badge/Android-15%2B-111111">
+  <img alt="Android 13+" src="https://img.shields.io/badge/Android-13%2B-111111">
   <a href="LICENSE"><img alt="Source-visible proprietary license" src="https://img.shields.io/badge/License-Proprietary-111111"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.2.3"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt showing the Recent scans dashboard, visual signature editor, and custom PDF size settings."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.2.4"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt showing the Recent scans dashboard, visual signature editor, and custom PDF size settings."></a>
 </p>
 
-## v1.2.3 update
+## v1.2.4 update
 
 The current stable release keeps the full Google scan editor with page previews,
 crop and rotate, and Google's filter gallery, then continues directly to the
@@ -29,8 +29,10 @@ after each change, survive navigation and updates, and default to deleting saved
 PDFs after sharing while retaining saved images. Visual signatures and stamps
 can be moved directly on a larger preview, resized and rotated with gestures, or
 fine-tuned from the collapsed Manual position panel.
+ScanIt now supports Android 13 and newer while keeping the same Google scanner,
+sharing, saving, and verified cleanup behavior.
 
-[Download ScanIt v1.2.3](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.3)
+[Download ScanIt v1.2.4](https://github.com/Majkey25/ScanIt/releases/tag/v1.2.4)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">
@@ -85,7 +87,7 @@ Download the
 
 Requirements for the current public code:
 
-- Android 15 or newer (`minSdk 35`, `targetSdk 36`).
+- Android 13 or newer (`minSdk 33`, `targetSdk 36`).
 - At least 1.7 GB total device RAM, required by ML Kit Document Scanner.
 - Google Play services for the scanner module.
 - A connection when Google Play services needs to download or update the scanner module.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,10 +17,10 @@ android {
 
     defaultConfig {
         applicationId = "com.majkeylab.scanit"
-        minSdk = 35
+        minSdk = 33
         targetSdk = 36
-        versionCode = 11
-        versionName = "1.2.3"
+        versionCode = 12
+        versionName = "1.2.4"
     }
 
     signingConfigs {

--- a/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
+++ b/app/src/main/assets/legal/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ Android release includes third-party components under their own licenses and
 terms.
 
 The `playReleaseRuntimeClasspath` graph was inspected for ScanIt
-`1.2.3` on 2026-08-13. Its direct runtime dependencies are:
+`1.2.4` on 2026-08-14. Its direct runtime dependencies are:
 
 - Kotlin standard library 2.4.10.
 - AndroidX Activity Compose 1.13.0.

--- a/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
+++ b/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.Process
 import android.provider.DocumentsContract
 import android.provider.MediaStore
-import android.service.chooser.ChooserResult
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
@@ -352,10 +351,13 @@ internal fun mayDeleteRecentCache(
 ): Boolean = allRequestedRemoved && metadataCommitted
 
 internal fun chooserResultAllowsCleanup(
-    resultType: Int,
+    resultType: Int?,
     selectedComponentPresent: Boolean,
 ): Boolean =
-    resultType == ChooserResult.CHOOSER_RESULT_SELECTED_COMPONENT && selectedComponentPresent
+    selectedComponentPresent &&
+        (resultType == null || resultType == CHOOSER_RESULT_SELECTED_COMPONENT)
+
+private const val CHOOSER_RESULT_SELECTED_COMPONENT = 0
 
 internal fun pdfTreeGrantsToRelease(
     persisted: Set<String>,

--- a/app/src/main/java/com/majkeylab/scanit/ShareResultReceiver.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ShareResultReceiver.kt
@@ -1,8 +1,10 @@
 package com.majkeylab.scanit
 
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.service.chooser.ChooserResult
 import android.widget.Toast
 import java.io.IOException
@@ -20,17 +22,7 @@ internal const val ACTION_SAVED_OUTPUTS_CHANGED =
 
 class ShareResultReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        val chooserResult =
-            intent.getParcelableExtra(Intent.EXTRA_CHOOSER_RESULT, ChooserResult::class.java)
-                ?: return
-        if (
-            !chooserResultAllowsCleanup(
-                chooserResult.type,
-                chooserResult.selectedComponent != null,
-            )
-        ) {
-            return
-        }
+        if (!intent.allowsShareCleanup()) return
         val request =
             decodeShareCleanupRequest(
                 intent.getStringExtra(EXTRA_SHARE_CACHE_ID),
@@ -59,6 +51,18 @@ class ShareResultReceiver : BroadcastReceiver() {
         }
     }
 }
+
+private fun Intent.allowsShareCleanup(): Boolean =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        val result = getParcelableExtra(Intent.EXTRA_CHOOSER_RESULT, ChooserResult::class.java)
+        chooserResultAllowsCleanup(result?.type, result?.selectedComponent != null)
+    } else {
+        chooserResultAllowsCleanup(
+            resultType = null,
+            selectedComponentPresent =
+                getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java) != null,
+        )
+    }
 
 internal fun retryPendingShareCleanup(context: Context): OutputDeleteOperationResult? {
     val store = SettingsStore(context)

--- a/app/src/test/java/com/majkeylab/scanit/DurableOutputDeleteTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/DurableOutputDeleteTest.kt
@@ -487,6 +487,22 @@ class DurableOutputDeleteTest {
     }
 
     @Test
+    fun legacyChooserCleanupRequiresChosenComponent() {
+        assertTrue(
+            chooserResultAllowsCleanup(
+                resultType = null,
+                selectedComponentPresent = true,
+            ),
+        )
+        assertFalse(
+            chooserResultAllowsCleanup(
+                resultType = null,
+                selectedComponentPresent = false,
+            ),
+        )
+    }
+
+    @Test
     fun shareCleanupRequestRequiresExactGenerationAndAvailableSavedKind() {
         assertEquals(
             ShareCleanupRequest(CACHE_ID, ENTRY_ID, ShareCleanupKind.Pdf),

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
   <main id="main">
     <section class="hero">
       <div class="container">
-        <p class="eyebrow">Android 15+</p>
+        <p class="eyebrow">Android 13+</p>
         <h1>Scan. Save. Share.</h1>
         <p class="hero-copy">A small document scanner that opens straight into capture and keeps file management out of the way.</p>
         <div class="actions">

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -139,7 +139,7 @@ processing, donations, or any unfinished feature.
 
 Reviewer note:
 
-> ScanIt requires no account. Opening it starts the Google ML Kit document scanner. Finish a scan to reach Result, or cancel to reach Recent scans. The camera and editing flow is supplied by Google Play services. Settings is available from the gear icon. The app supports Android 15 and newer, requires Google Play services, and ML Kit requires at least 1.7 GB total device RAM.
+> ScanIt requires no account. Opening it starts the Google ML Kit document scanner. Finish a scan to reach Result, or cancel to reach Recent scans. The camera and editing flow is supplied by Google Play services. Settings is available from the gear icon. The app supports Android 13 and newer, requires Google Play services, and ML Kit requires at least 1.7 GB total device RAM.
 
 ### Ads
 

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -18,8 +18,8 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "11"
-$expectedMinSdk = "35"
+$expectedVersionCode = "12"
+$expectedMinSdk = "33"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
 $sdkRootWasExplicit = $PSBoundParameters.ContainsKey("SdkRoot")
@@ -27,15 +27,15 @@ $sdkRootWasExplicit = $PSBoundParameters.ContainsKey("SdkRoot")
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.2.3-internal"
+        $expectedVersionName = "1.2.4-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.2.3"
+        $expectedVersionName = "1.2.4"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.2.3"
+        $expectedVersionName = "1.2.4"
     }
 }
 


### PR DESCRIPTION
Expands ScanIt support to Android 13+ (minSdk 33), adds the Android 13/14 chooser callback fallback for delete-after-sharing, bumps version to 1.2.4 / code 12, and updates release documentation. Verified by the full signed release gate plus live API 33 Google ML Kit scanner, cancel navigation, settings persistence, and crash-buffer checks.