### PR TITLE
fix: clarify missing saved outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here.
 
+## [1.3.6] - 2026-08-17
+
+### Fixed
+
+- Replaced technical provider URIs in File details with readable storage paths.
+- Detects a saved PDF that was deleted outside the app and offers a direct Save action to recreate it.
+
 ## [1.3.5] - 2026-08-17
 
 ### Changed
@@ -205,6 +212,7 @@ Historical copies retain the license supplied with them. See
 [1.3.2]: https://github.com/Majkey25/ScanIt/compare/v1.3.1...v1.3.2
 [1.3.3]: https://github.com/Majkey25/ScanIt/compare/v1.3.2...v1.3.3
 [1.3.4]: https://github.com/Majkey25/ScanIt/compare/v1.3.3...v1.3.4
+[1.3.6]: https://github.com/Majkey25/ScanIt/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/Majkey25/ScanIt/compare/v1.3.4...v1.3.5
 [1.2.1]: https://github.com/Majkey25/ScanIt/compare/v1.2.0...v1.2.1
 [1.1.0-alpha.1]: https://github.com/Majkey25/ScanIt/compare/v1.0.0-preview.1...main

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.5"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt v1.3.5 showing the Result screen, file controls, and visual signature editor."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.6"><img src="docs/images/scanit-v1.1-update.png" width="100%" alt="ScanIt v1.3.6 showing the Result screen, file controls, and visual signature editor."></a>
 </p>
 
-## v1.3.5 update
+## v1.3.6 update
 
 The current stable release keeps the full Google scan editor with page previews,
 crop and rotate, and Google's filter gallery, then continues directly to the
@@ -48,7 +48,7 @@ PDF and image changes into compact Size, Format, and Location controls.
 After a full app restart, ScanIt opens a fresh scanner session instead of reopening
 the previously viewed Result; completed scans remain available from Recent.
 
-[Download ScanIt v1.3.5](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.5)
+[Download ScanIt v1.3.6](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.6)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 33
         targetSdk = 36
-        versionCode = 19
-        versionName = "1.3.5"
+        versionCode = 20
+        versionName = "1.3.6"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/majkeylab/scanit/AppUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/AppUi.kt
@@ -865,6 +865,7 @@ private fun ResultScreen(
                         saveInProgress = result.outputSaveInProgress,
                         outputChangeInProgress = result.outputChangeInProgress,
                         onSaveNow = { showSaveDialog = true },
+                        onSavePdfNow = { onSaveNow(SaveNowTarget.Pdf) },
                         onChangePdfSize = { showPdfSizeDialog = true },
                         onChangePdfLocation = onChangePdfLocation,
                         onChangeImageSize = { showImageSizeDialog = true },
@@ -1676,6 +1677,7 @@ private fun FileDetails(
     saveInProgress: Boolean,
     outputChangeInProgress: Boolean,
     onSaveNow: () -> Unit,
+    onSavePdfNow: () -> Unit,
     onChangePdfSize: () -> Unit,
     onChangePdfLocation: () -> Unit,
     onChangeImageSize: () -> Unit,
@@ -1695,12 +1697,20 @@ private fun FileDetails(
     val stackFileDetailControls =
         availableWidthDp < 360 || configuration.fontScale >= 1.3f
     val pdfLocation =
-        scan.savedPdfLocation
-            ?: scan.savedPdf?.toString()
-            ?: stringResource(R.string.file_not_saved)
+        when {
+            scan.savedPdfDeleted -> ""
+            scan.savedPdf == null -> stringResource(R.string.file_not_saved)
+            else ->
+                displayOutputLocationPath(scan.savedPdfLocation)
+                    ?: stringResource(R.string.not_available)
+        }
     val pdfStatus =
         stringResource(
-            if (scan.savedPdf == null) R.string.file_temporary else R.string.file_saved,
+            when {
+                scan.savedPdfDeleted -> R.string.file_deleted
+                scan.savedPdf == null -> R.string.file_temporary
+                else -> R.string.file_saved
+            },
         )
     val imagesLocation = imageLocationLabel(scan)
     val pdfDisplayName = scan.savedPdfDisplayName ?: scan.cached.pdf.name
@@ -1794,9 +1804,16 @@ private fun FileDetails(
                 label = stringResource(R.string.target_size),
                 value = pdfSizeTargetLabel(scan.cached.pdfSizeTarget),
             )
-            FileDetailRow(
+            FileDetailStatusRow(
                 label = stringResource(R.string.status),
                 value = pdfStatus,
+                actionLabel = stringResource(R.string.save).takeIf { scan.savedPdfDeleted },
+                actionEnabled =
+                    scan.savedPdfDeleted &&
+                        SaveNowTarget.Pdf in saveTargets &&
+                        !saveInProgress &&
+                        !outputChangeInProgress,
+                onAction = onSavePdfNow,
             )
             FileDetailRow(
                 label = stringResource(R.string.location),
@@ -2133,11 +2150,49 @@ private fun FileDetailRow(
 }
 
 @Composable
+private fun FileDetailStatusRow(
+    label: String,
+    value: String,
+    actionLabel: String?,
+    actionEnabled: Boolean,
+    onAction: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Row(
+            modifier = Modifier.weight(1.2f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(value, style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+            if (actionLabel != null) {
+                TextButton(
+                    onClick = onAction,
+                    enabled = actionEnabled,
+                    modifier = Modifier.heightIn(min = 40.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp),
+                ) {
+                    Text(actionLabel)
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun imageLocationLabel(scan: SavedScan): String {
     if (scan.savedImages.isEmpty()) return stringResource(R.string.file_not_saved)
-    return requireNotNull(
-        imageOutputLocationLabel(scan.savedImages.map { it.location ?: it.uri.toString() }),
-    )
+    val locations = scan.savedImages.mapNotNull { displayOutputLocationPath(it.location) }
+    return imageOutputLocationLabel(locations) ?: stringResource(R.string.not_available)
 }
 
 @Composable

--- a/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
+++ b/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
@@ -270,6 +270,15 @@ private inline fun providerDeleteResult(operation: () -> OutputDeleteStatus): Ou
         OutputDeleteStatus.Failed
     }
 
+private inline fun providerQueryResult(operation: () -> ExactItemQuery): ExactItemQuery =
+    try {
+        operation()
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Exception) {
+        ExactItemQuery.Failed
+    }
+
 internal fun isExactSafDocument(
     row: SafDocumentRow,
     expectedDocumentId: String,
@@ -424,6 +433,30 @@ internal fun reconcileOutputTreeGrants(
 
 internal class ExactOutputDeleter(private val context: Context) {
     private val resolver = context.contentResolver
+
+    fun queryPdf(reference: PdfOutputRef): ExactItemQuery =
+        providerQueryResult {
+            reference.outputFingerprint() ?: return@providerQueryResult ExactItemQuery.Failed
+            if (reference.treeUri != null) {
+                if (reference.ownerPackageName != null || reference.mimeType != PDF_MIME_TYPE) {
+                    return@providerQueryResult ExactItemQuery.IdentityMismatch
+                }
+                return@providerQueryResult querySafOutput(
+                    uriValue = reference.uri,
+                    treeUriValue = reference.treeUri,
+                    displayName = reference.displayName,
+                    mimeType = reference.mimeType,
+                )
+            }
+            val identity =
+                expectedMediaIdentity(
+                    reference.displayName,
+                    reference.mimeType,
+                    reference.ownerPackageName,
+                    PDF_MIME_TYPE,
+                ) ?: return@providerQueryResult ExactItemQuery.IdentityMismatch
+            queryMediaOutput(reference.uri, MediaOutputCollection.Downloads, identity)
+        }
 
     fun deletePdf(reference: PdfOutputRef): OutputDeleteStatus =
         reference.outputFingerprint()?.let { fingerprint ->
@@ -713,6 +746,34 @@ internal class ExactOutputDeleter(private val context: Context) {
         )
     }
 
+    private fun queryMediaOutput(
+        uriValue: String,
+        collection: MediaOutputCollection,
+        expectedIdentity: MediaItemRow,
+    ): ExactItemQuery {
+        val address = parseMediaItemAddress(uriValue) ?: return ExactItemQuery.IdentityMismatch
+        if (address.collection != collection) return ExactItemQuery.IdentityMismatch
+        val uri = Uri.parse(uriValue)
+        val canonical =
+            when (collection) {
+                MediaOutputCollection.Images ->
+                    MediaStore.Images.Media.getContentUri(address.volume, address.id)
+                MediaOutputCollection.Downloads ->
+                    MediaStore.Downloads.getContentUri(address.volume, address.id)
+            }
+        if (canonical != uri) return ExactItemQuery.IdentityMismatch
+        val owner = expectedIdentity.ownerPackageName ?: return ExactItemQuery.IdentityMismatch
+        return queryMediaItem(
+            uri,
+            ExpectedMediaItem(
+                address.id,
+                expectedIdentity.displayName,
+                expectedIdentity.mimeType,
+                owner,
+            ),
+        )
+    }
+
     private fun queryMediaItem(uri: Uri, expected: ExpectedMediaItem): ExactItemQuery {
         val cursor =
             resolver.query(
@@ -804,6 +865,58 @@ internal class ExactOutputDeleter(private val context: Context) {
             throw cancellation
         } catch (_: Exception) {
             OutputDeleteStatus.Failed
+        }
+    }
+
+    private fun querySafOutput(
+        uriValue: String,
+        treeUriValue: String,
+        displayName: String?,
+        mimeType: String?,
+    ): ExactItemQuery {
+        val exactDisplayName = displayName ?: return ExactItemQuery.IdentityMismatch
+        val exactMimeType = mimeType ?: return ExactItemQuery.IdentityMismatch
+        if (exactMimeType != PDF_MIME_TYPE) return ExactItemQuery.IdentityMismatch
+        val tree = exactContentUri(treeUriValue) ?: return ExactItemQuery.IdentityMismatch
+        val document = exactContentUri(uriValue) ?: return ExactItemQuery.IdentityMismatch
+        if (tree.authority != document.authority) return ExactItemQuery.IdentityMismatch
+        if (
+            !DocumentsContract.isTreeUri(tree) ||
+                !DocumentsContract.isDocumentUri(context, document) ||
+                resolver.persistedUriPermissions.none {
+                    it.uri == tree && it.isReadPermission && it.isWritePermission
+                }
+        ) return ExactItemQuery.IdentityMismatch
+        val rootId = DocumentsContract.getTreeDocumentId(tree)
+        val documentId = DocumentsContract.getDocumentId(document)
+        val root = DocumentsContract.buildDocumentUriUsingTree(tree, rootId)
+        if (
+            rootId == documentId ||
+                DocumentsContract.getTreeDocumentId(document) != rootId ||
+                DocumentsContract.buildTreeDocumentUri(tree.authority!!, rootId) != tree ||
+                DocumentsContract.buildDocumentUriUsingTree(tree, documentId) != document ||
+                context.checkUriPermission(
+                    document,
+                    Process.myPid(),
+                    Process.myUid(),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                ) != PackageManager.PERMISSION_GRANTED
+        ) return ExactItemQuery.IdentityMismatch
+        return when (querySafDocument(document, documentId, exactDisplayName, exactMimeType)) {
+            ExactItemQuery.Absent ->
+                if (
+                    confirmSafDocumentAbsent(
+                        root,
+                        rootId,
+                        document,
+                        documentId,
+                        exactDisplayName,
+                        exactMimeType,
+                    ) == OutputDeleteStatus.Absent
+                ) ExactItemQuery.Absent else ExactItemQuery.Failed
+            ExactItemQuery.Exact -> ExactItemQuery.Exact
+            ExactItemQuery.IdentityMismatch -> ExactItemQuery.IdentityMismatch
+            ExactItemQuery.Failed -> ExactItemQuery.Failed
         }
     }
 

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -378,6 +378,43 @@ internal fun outputLocationPath(directory: String, displayName: String?): String
     return "${directory.trimEnd('/')}/$name"
 }
 
+internal fun displayOutputLocationPath(value: String?): String? {
+    val path = value?.replace('\\', '/')?.trimEnd('/') ?: return null
+    if (path.isBlank() || path.startsWith("content://", ignoreCase = true)) return null
+    val internalRoot = "/storage/emulated/0"
+    if (path == internalRoot) return "Internal storage"
+    if (path.startsWith("$internalRoot/")) {
+        val relative = path.removePrefix("$internalRoot/")
+        val readable =
+            if (relative == "Download" || relative.startsWith("Download/")) {
+                "Downloads${relative.removePrefix("Download")}"
+            } else {
+                relative
+            }
+        return "Internal storage/$readable"
+    }
+    if (path.startsWith("/storage/")) {
+        val relative = path.removePrefix("/storage/").substringAfter('/', missingDelimiterValue = "")
+        return if (relative.isBlank()) "External storage" else "External storage/$relative"
+    }
+    return path
+}
+
+internal data class VisiblePdfOutput(
+    val reference: PdfOutputRef?,
+    val deleted: Boolean,
+)
+
+internal fun visiblePdfOutput(
+    reference: PdfOutputRef?,
+    query: (PdfOutputRef) -> ExactItemQuery,
+): VisiblePdfOutput =
+    when {
+        reference == null -> VisiblePdfOutput(null, false)
+        query(reference) == ExactItemQuery.Absent -> VisiblePdfOutput(null, true)
+        else -> VisiblePdfOutput(reference, false)
+    }
+
 internal fun imageOutputLocationLabel(locations: List<String>): String? {
     val unique = locations.distinct()
     if (unique.isEmpty()) return null
@@ -718,6 +755,7 @@ internal data class SavedScan(
     val savedPdfTree: Uri? = null,
     val savedPdfDisplayName: String? = null,
     val savedPdfLocation: String? = null,
+    val savedPdfDeleted: Boolean = false,
     val warnings: List<UiMessage> = emptyList(),
     val outputMetadataValid: Boolean = false,
     val savedPdfDeleteVerified: Boolean = false,

--- a/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
@@ -3022,16 +3022,29 @@ internal class ScanStorage(
                     if (existing.pending) {
                         throw IOException("Saved PDF publication is still pending")
                     }
-                    return@withLock SavedPdfOutput(
-                        uri = existing.uri.toUri(),
-                        treeUri = existing.treeUri?.toUri(),
-                        warning = null,
-                        displayName = existing.displayName,
-                        mimeType = existing.mimeType,
-                        ownerPackageName = existing.ownerPackageName,
-                        byteLength = existing.byteLength,
-                        sha256 = existing.sha256,
-                    )
+                    when (outputDeleter.queryPdf(existing)) {
+                        ExactItemQuery.Exact ->
+                            return@withLock SavedPdfOutput(
+                                uri = existing.uri.toUri(),
+                                treeUri = existing.treeUri?.toUri(),
+                                warning = null,
+                                displayName = existing.displayName,
+                                mimeType = existing.mimeType,
+                                ownerPackageName = existing.ownerPackageName,
+                                byteLength = existing.byteLength,
+                                sha256 = existing.sha256,
+                            )
+                        ExactItemQuery.Absent ->
+                            rewriteCachedOutputMetadata(cached) { metadata ->
+                                if (metadata.pdf != existing) {
+                                    throw IOException("Saved PDF authority changed")
+                                }
+                                metadata.copy(pdf = null)
+                            }
+                        ExactItemQuery.IdentityMismatch,
+                        ExactItemQuery.Failed,
+                        -> throw IOException("Saved PDF identity could not be verified")
+                    }
                 }
                 val output =
                     if (pdfTreeUri != null) {
@@ -3266,6 +3279,7 @@ internal class ScanStorage(
         unknownOutputCreateAcknowledgement: UnknownOutputCreateAcknowledgement? = null,
     ): SavedScan {
         val activePdf = metadata?.pdf?.takeUnless(PdfOutputRef::pending)
+        val visiblePdf = visiblePdfOutput(activePdf, outputDeleter::queryPdf)
         val activeImages = metadata?.images?.filterNot(ImageOutputRef::pending).orEmpty()
         val exact = metadata?.takeIf { it.hasCompleteExactDeleteInventory(context.packageName) }
         return SavedScan(
@@ -3295,11 +3309,11 @@ internal class ScanStorage(
                             ),
                     )
                 },
-            savedPdf = activePdf?.uri?.toUri(),
-            savedPdfTree = activePdf?.treeUri?.toUri(),
+            savedPdf = visiblePdf.reference?.uri?.toUri(),
+            savedPdfTree = visiblePdf.reference?.treeUri?.toUri(),
             savedPdfDisplayName = activePdf?.displayName,
             savedPdfLocation =
-                activePdf?.let {
+                visiblePdf.reference?.let {
                     savedOutputLocation(
                         treeUri = it.treeUri,
                         uri = it.uri,
@@ -3307,11 +3321,13 @@ internal class ScanStorage(
                         collection = MediaOutputCollection.Downloads,
                     )
                 },
+            savedPdfDeleted = visiblePdf.deleted,
             warnings =
                 (warnings + listOfNotNull(pdfSizeTargetWarning(cached.pdfSizeTarget, cached.pdf.length())))
                     .distinct(),
             outputMetadataValid = metadata != null && !mutationBlocked,
-            savedPdfDeleteVerified = !mutationBlocked && exact?.pdf == activePdf && activePdf != null,
+            savedPdfDeleteVerified =
+                !mutationBlocked && exact?.pdf == visiblePdf.reference && visiblePdf.reference != null,
             savedImagesDeleteVerified =
                 !mutationBlocked && activeImages.isNotEmpty() &&
                     exact?.images == activeImages,
@@ -3324,7 +3340,7 @@ internal class ScanStorage(
         uri: String,
         displayName: String?,
         collection: MediaOutputCollection,
-    ): String {
+    ): String? {
         if (treeUri != null) {
             val tree = treeUri.toUri()
             if (tree.authority == "com.android.externalstorage.documents") {
@@ -3338,13 +3354,13 @@ internal class ScanStorage(
                     }
                 directory?.let { outputLocationPath(it, displayName) }?.let { return it }
             }
-            return uri
+            return null
         }
         val address = parseMediaItemAddress(uri)
-        if (address?.collection != collection) return uri
-        val relativePath = readMediaRelativePath(uri.toUri()) ?: return uri
-        val directory = mediaStoreDirectoryPath(address.volume, relativePath) ?: return uri
-        return outputLocationPath(directory, displayName) ?: uri
+        if (address?.collection != collection) return null
+        val relativePath = readMediaRelativePath(uri.toUri()) ?: return null
+        val directory = mediaStoreDirectoryPath(address.volume, relativePath) ?: return null
+        return outputLocationPath(directory, displayName)
     }
 
     private fun readMediaRelativePath(uri: Uri): String? =

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -38,6 +38,7 @@
     <string name="fullscreen_preview_hint">Stažením prstů měňte přiblížení, tažením posouvejte a dvojitým klepnutím obnovte zobrazení.</string>
     <string name="file_saved">Uloženo</string>
     <string name="file_temporary">Dočasné</string>
+    <string name="file_deleted">Smazáno</string>
     <string name="file_not_saved">Neuloženo</string>
     <string name="pdf_document">PDF</string>
     <string name="images">Obrázky</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -36,6 +36,7 @@
     <string name="fullscreen_preview_hint">Mit zwei Fingern zoomen, zum Verschieben ziehen oder zum Zurücksetzen doppeltippen.</string>
     <string name="file_saved">Gespeichert</string>
     <string name="file_temporary">Temporär</string>
+    <string name="file_deleted">Gelöscht</string>
     <string name="file_not_saved">Nicht gespeichert</string>
     <string name="pdf_document">PDF</string>
     <string name="images">Bilder</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,6 +37,7 @@
     <string name="fullscreen_preview_hint">Pellizca para ampliar, arrastra para mover o toca dos veces para restablecer.</string>
     <string name="file_saved">Guardado</string>
     <string name="file_temporary">Temporal</string>
+    <string name="file_deleted">Eliminado</string>
     <string name="file_not_saved">No guardado</string>
     <string name="pdf_document">PDF</string>
     <string name="images">Imágenes</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -35,6 +35,7 @@
     <string name="fullscreen_preview_hint">双指缩放、拖动平移，或双击重置。</string>
     <string name="file_saved">已保存</string>
     <string name="file_temporary">临时</string>
+    <string name="file_deleted">已删除</string>
     <string name="file_not_saved">未保存</string>
     <string name="pdf_document">PDF</string>
     <string name="images">图片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="fullscreen_preview_hint">Pinch to zoom, drag to pan, or double-tap to reset.</string>
     <string name="file_saved">Saved</string>
     <string name="file_temporary">Temporary</string>
+    <string name="file_deleted">Deleted</string>
     <string name="file_not_saved">Not saved</string>
     <string name="pdf_document">PDF</string>
     <string name="images">Images</string>

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -156,6 +156,49 @@ class PureLogicTest {
     }
 
     @Test
+    fun fileDetailsShowReadableStoragePathsAndNeverProviderUris() {
+        assertEquals(
+            "Internal storage/Downloads/Scan to PDF/Practice sheet.pdf",
+            displayOutputLocationPath(
+                "/storage/emulated/0/Download/Scan to PDF/Practice sheet.pdf",
+            ),
+        )
+        assertEquals(
+            "External storage/Documents/Scans/Practice sheet.pdf",
+            displayOutputLocationPath(
+                "/storage/ABCD-1234/Documents/Scans/Practice sheet.pdf",
+            ),
+        )
+        assertNull(displayOutputLocationPath("content://media/external/downloads/15911"))
+        assertNull(displayOutputLocationPath(null))
+    }
+
+    @Test
+    fun missingPdfIsShownAsDeletedOnlyAfterProviderConfirmsAbsence() {
+        val reference =
+            PdfOutputRef(
+                uri = "content://media/external/downloads/15911",
+                treeUri = null,
+                displayName = "Practice sheet.pdf",
+                mimeType = "application/pdf",
+                ownerPackageName = "com.majkeylab.scanit",
+                byteLength = 123L,
+                sha256 = "01".repeat(32),
+            )
+
+        val deleted = visiblePdfOutput(reference) { ExactItemQuery.Absent }
+        assertNull(deleted.reference)
+        assertTrue(deleted.deleted)
+
+        listOf(ExactItemQuery.Exact, ExactItemQuery.IdentityMismatch, ExactItemQuery.Failed)
+            .forEach { status ->
+                val retained = visiblePdfOutput(reference) { status }
+                assertEquals(reference, retained.reference)
+                assertFalse(retained.deleted)
+            }
+    }
+
+    @Test
     fun outputNamesRejectPathsControlsAndEmptyValues() {
         listOf(
             "",

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -19,8 +19,8 @@ submitted declarations:
 |---|---|
 | App name | `ScanIt` |
 | Package | `com.majkeylab.scanit` |
-| Version code | `19` |
-| Version name | `1.3.5` |
+| Version code | `20` |
+| Version name | `1.3.6` |
 | Default language | English (United States) |
 | App or game | App |
 | Category | Productivity |
@@ -126,29 +126,29 @@ the Play developer account.
 >
 > Skener používá Google ML Kit Document Scanner a vyžaduje služby Google Play. Služby Google Play mohou před prvním použitím stáhnout modul skeneru nebo rozpoznávání a zpracovávat omezené diagnostické a provozní údaje.
 
-## Release notes — version 19 / 1.3.5
+## Release notes — version 20 / 1.3.6
 
 Each block is below Google Play's 500-character per-language limit.
 
 ### English (United States)
 
-> Rename saved PDFs and image sets in a compact inline editor with a fixed visible extension. File details now shows each output's full resolved location instead of a vague folder label. The Review every page and File details screenshots now match the released English interface.
+> File details now shows readable storage paths instead of technical provider addresses. If a saved PDF was deleted outside the app, ScanIt clearly marks it as Deleted and offers a direct Save action to recreate it.
 
 ### Čeština
 
-> Uložená PDF i sady obrázků lze přejmenovat v kompaktním editoru s pevně zobrazenou příponou. Detaily souboru nyní ukazují úplnou cestu k výstupu místo neurčitého názvu složky. Aktualizované snímky odpovídají vydané anglické verzi.
+> Detaily souboru nyní ukazují čitelné cesty místo technických adres poskytovatele. Pokud bylo uložené PDF smazáno mimo aplikaci, ScanIt ho označí jako Smazáno a nabídne přímé tlačítko Uložit pro jeho obnovení.
 
 ### Deutsch
 
-> PDFs und Bildsätze lassen sich in einem kompakten Editor mit fest sichtbarer Dateiendung umbenennen. Die Dateidetails zeigen jetzt den vollständigen Ausgabeort statt einer ungenauen Ordnerbezeichnung. Die aktualisierten Screenshots entsprechen der veröffentlichten englischen Oberfläche.
+> Die Dateidetails zeigen jetzt lesbare Speicherpfade statt technischer Anbieteradressen. Wird eine gespeicherte PDF außerhalb der App gelöscht, markiert ScanIt sie als Gelöscht und bietet eine direkte Speichern-Aktion zum Wiederherstellen an.
 
 ### Español
 
-> Ahora puedes renombrar PDF e imágenes con un editor compacto y una extensión visible que no se puede modificar. Detalles del archivo muestra la ubicación completa de cada salida en vez de una carpeta imprecisa. Las capturas actualizadas coinciden con la interfaz publicada en inglés.
+> Detalles del archivo ahora muestra rutas de almacenamiento legibles en vez de direcciones técnicas. Si un PDF guardado se elimina fuera de la app, ScanIt lo marca como Eliminado y ofrece una acción Guardar directa para recrearlo.
 
 ### 简体中文
 
-> 现在可通过紧凑的行内编辑器重命名 PDF 和图像组，文件扩展名始终可见且不可修改。文件详情会显示完整输出位置，不再使用模糊的文件夹名称。更新后的截图与已发布的英文界面一致。
+> 文件详情现在显示易读的存储路径，不再显示技术性提供程序地址。如果已保存的 PDF 在应用外被删除，ScanIt 会将其标记为已删除，并提供直接的保存操作来重新创建文件。
 
 The listing describes current implemented public behavior only. It does not
 claim certificate-backed signatures, guaranteed PDF compression, cloud
@@ -326,7 +326,7 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 19, version `1.3.5`; verify after the final release build.
+- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 20, version `1.3.6`; verify after the final release build.
 - [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
 - [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
 - [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "19"
+$expectedVersionCode = "20"
 $expectedMinSdk = "33"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -99,15 +99,15 @@ Assert-ReleasePolicyConfiguration
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.3.5-internal"
+        $expectedVersionName = "1.3.6-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.3.5"
+        $expectedVersionName = "1.3.6"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.3.5"
+        $expectedVersionName = "1.3.6"
     }
 }
 


### PR DESCRIPTION
## Summary
- show readable storage paths instead of provider URIs
- detect PDFs deleted outside the app and offer direct Save recovery
- prepare version 1.3.6 release metadata

## Verification
- 481 internal JVM tests, 0 failures/errors/skips
- lintInternalDebug: 0 errors
- assembleInternalDebug: pass
- emulator API 35: present PDF, external delete, Deleted/Save, recreated PDF, image regression