### PR TITLE
fix: show output folders without file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes are documented here.
 
+## [1.3.7] - 2026-08-17
+
+### Fixed
+
+- File details now shows only the containing folder in Location; the file name remains in its separate editable field.
+
 ## [1.3.6] - 2026-08-17
 
 ### Fixed
@@ -212,6 +218,7 @@ Historical copies retain the license supplied with them. See
 [1.3.2]: https://github.com/Majkey25/ScanIt/compare/v1.3.1...v1.3.2
 [1.3.3]: https://github.com/Majkey25/ScanIt/compare/v1.3.2...v1.3.3
 [1.3.4]: https://github.com/Majkey25/ScanIt/compare/v1.3.3...v1.3.4
+[1.3.7]: https://github.com/Majkey25/ScanIt/compare/v1.3.6...v1.3.7
 [1.3.6]: https://github.com/Majkey25/ScanIt/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/Majkey25/ScanIt/compare/v1.3.4...v1.3.5
 [1.2.1]: https://github.com/Majkey25/ScanIt/compare/v1.2.0...v1.2.1

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.6"><img src="docs/images/scanit-current-overview.png" width="100%" alt="Current ScanIt workflow showing capture, result and sharing, file controls, and signature placement."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.7"><img src="docs/images/scanit-current-overview.png" width="100%" alt="Current ScanIt v1.3.7 workflow showing capture, result and sharing, file controls, and signature placement."></a>
 </p>
 
-## v1.3.6 update
+## v1.3.7 update
 
 The current stable release keeps the full Google scan editor with page previews,
 crop and rotate, and Google's filter gallery, then continues directly to the
@@ -48,7 +48,7 @@ PDF and image changes into compact Size, Format, and Location controls.
 After a full app restart, ScanIt opens a fresh scanner session instead of reopening
 the previously viewed Result; completed scans remain available from Recent.
 
-[Download ScanIt v1.3.6](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.6)
+[Download ScanIt v1.3.7](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.7)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 33
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.3.6"
+        versionCode = 21
+        versionName = "1.3.7"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -381,10 +381,12 @@ internal fun outputLocationPath(directory: String, displayName: String?): String
 internal fun displayOutputLocationPath(value: String?): String? {
     val path = value?.replace('\\', '/')?.trimEnd('/') ?: return null
     if (path.isBlank() || path.startsWith("content://", ignoreCase = true)) return null
+    val directory = path.substringBeforeLast('/', missingDelimiterValue = "")
+    if (directory.isBlank()) return null
     val internalRoot = "/storage/emulated/0"
-    if (path == internalRoot) return "Internal storage"
-    if (path.startsWith("$internalRoot/")) {
-        val relative = path.removePrefix("$internalRoot/")
+    if (directory == internalRoot) return "Internal storage"
+    if (directory.startsWith("$internalRoot/")) {
+        val relative = directory.removePrefix("$internalRoot/")
         val readable =
             if (relative == "Download" || relative.startsWith("Download/")) {
                 "Downloads${relative.removePrefix("Download")}"
@@ -393,11 +395,11 @@ internal fun displayOutputLocationPath(value: String?): String? {
             }
         return "Internal storage/$readable"
     }
-    if (path.startsWith("/storage/")) {
-        val relative = path.removePrefix("/storage/").substringAfter('/', missingDelimiterValue = "")
+    if (directory.startsWith("/storage/")) {
+        val relative = directory.removePrefix("/storage/").substringAfter('/', missingDelimiterValue = "")
         return if (relative.isBlank()) "External storage" else "External storage/$relative"
     }
-    return path
+    return directory
 }
 
 internal data class VisiblePdfOutput(

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -158,15 +158,21 @@ class PureLogicTest {
     @Test
     fun fileDetailsShowReadableStoragePathsAndNeverProviderUris() {
         assertEquals(
-            "Internal storage/Downloads/Scan to PDF/Practice sheet.pdf",
+            "Internal storage/Downloads/Scan to PDF",
             displayOutputLocationPath(
                 "/storage/emulated/0/Download/Scan to PDF/Practice sheet.pdf",
             ),
         )
         assertEquals(
-            "External storage/Documents/Scans/Practice sheet.pdf",
+            "External storage/Documents/Scans",
             displayOutputLocationPath(
                 "/storage/ABCD-1234/Documents/Scans/Practice sheet.pdf",
+            ),
+        )
+        assertEquals(
+            "Internal storage/Pictures/Scan to PDF",
+            displayOutputLocationPath(
+                "/storage/emulated/0/Pictures/Scan to PDF/Page 01.png",
             ),
         )
         assertNull(displayOutputLocationPath("content://media/external/downloads/15911"))

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -19,8 +19,8 @@ submitted declarations:
 |---|---|
 | App name | `ScanIt` |
 | Package | `com.majkeylab.scanit` |
-| Version code | `20` |
-| Version name | `1.3.6` |
+| Version code | `21` |
+| Version name | `1.3.7` |
 | Default language | English (United States) |
 | App or game | App |
 | Category | Productivity |
@@ -126,29 +126,29 @@ the Play developer account.
 >
 > Skener používá Google ML Kit Document Scanner a vyžaduje služby Google Play. Služby Google Play mohou před prvním použitím stáhnout modul skeneru nebo rozpoznávání a zpracovávat omezené diagnostické a provozní údaje.
 
-## Release notes — version 20 / 1.3.6
+## Release notes — version 21 / 1.3.7
 
 Each block is below Google Play's 500-character per-language limit.
 
 ### English (United States)
 
-> File details now shows readable storage paths instead of technical provider addresses. If a saved PDF was deleted outside the app, ScanIt clearly marks it as Deleted and offers a direct Save action to recreate it.
+> File details now shows only the containing folder in Location. The PDF or image name stays in its separate editable field, keeping saved-file information clear and compact.
 
 ### Čeština
 
-> Detaily souboru nyní ukazují čitelné cesty místo technických adres poskytovatele. Pokud bylo uložené PDF smazáno mimo aplikaci, ScanIt ho označí jako Smazáno a nabídne přímé tlačítko Uložit pro jeho obnovení.
+> Detaily souboru nyní v poli Umístění ukazují jen cílovou složku. Název PDF nebo obrázku zůstává v samostatném upravitelném poli, takže jsou informace přehlednější.
 
 ### Deutsch
 
-> Die Dateidetails zeigen jetzt lesbare Speicherpfade statt technischer Anbieteradressen. Wird eine gespeicherte PDF außerhalb der App gelöscht, markiert ScanIt sie als Gelöscht und bietet eine direkte Speichern-Aktion zum Wiederherstellen an.
+> Die Dateidetails zeigen unter Speicherort nur noch den Zielordner. Der Name der PDF- oder Bilddatei bleibt im separaten bearbeitbaren Feld, sodass die Ansicht kompakt bleibt.
 
 ### Español
 
-> Detalles del archivo ahora muestra rutas de almacenamiento legibles en vez de direcciones técnicas. Si un PDF guardado se elimina fuera de la app, ScanIt lo marca como Eliminado y ofrece una acción Guardar directa para recrearlo.
+> Detalles del archivo ahora muestra solo la carpeta de destino en Ubicación. El nombre del PDF o de la imagen permanece en su campo editable separado para una vista más clara.
 
 ### 简体中文
 
-> 文件详情现在显示易读的存储路径，不再显示技术性提供程序地址。如果已保存的 PDF 在应用外被删除，ScanIt 会将其标记为已删除，并提供直接的保存操作来重新创建文件。
+> 文件详情中的位置现在仅显示目标文件夹。PDF 或图片名称仍保留在单独的可编辑字段中，使保存信息更清晰、更紧凑。
 
 The listing describes current implemented public behavior only. It does not
 claim certificate-backed signatures, guaranteed PDF compression, cloud
@@ -326,7 +326,7 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 20, version `1.3.6`; verify after the final release build.
+- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 21, version `1.3.7`; verify after the final release build.
 - [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
 - [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
 - [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "20"
+$expectedVersionCode = "21"
 $expectedMinSdk = "33"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -99,15 +99,15 @@ Assert-ReleasePolicyConfiguration
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.3.6-internal"
+        $expectedVersionName = "1.3.7-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.3.6"
+        $expectedVersionName = "1.3.7"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.3.6"
+        $expectedVersionName = "1.3.7"
     }
 }
 


### PR DESCRIPTION
## Summary
- show only the containing folder in File details Location
- keep PDF/image names in their separate editable fields
- bump public release to 1.3.7 (code 21)

## Verification
- PureLogicTest RED then GREEN
- 481 internal JVM tests, 0 failures
- lintInternalDebug 0 errors
- assembleInternalDebug PASS