### PR TITLE
fix: recover externally deleted outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here.
 
+## [1.3.8] - 2026-08-17
+
+### Fixed
+
+- File details keeps Deleted status rows aligned and detects externally deleted saved images.
+- Missing PDFs and images can each be recreated directly with Save without reusing stale provider URIs.
+
 ## [1.3.7] - 2026-08-17
 
 ### Fixed
@@ -218,6 +225,7 @@ Historical copies retain the license supplied with them. See
 [1.3.2]: https://github.com/Majkey25/ScanIt/compare/v1.3.1...v1.3.2
 [1.3.3]: https://github.com/Majkey25/ScanIt/compare/v1.3.2...v1.3.3
 [1.3.4]: https://github.com/Majkey25/ScanIt/compare/v1.3.3...v1.3.4
+[1.3.8]: https://github.com/Majkey25/ScanIt/compare/v1.3.7...v1.3.8
 [1.3.7]: https://github.com/Majkey25/ScanIt/compare/v1.3.6...v1.3.7
 [1.3.6]: https://github.com/Majkey25/ScanIt/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/Majkey25/ScanIt/compare/v1.3.4...v1.3.5

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.7"><img src="docs/images/scanit-current-overview.png" width="100%" alt="Current ScanIt v1.3.7 workflow showing capture, result and sharing, file controls, and signature placement."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.3.8"><img src="docs/images/scanit-current-overview.png" width="100%" alt="Current ScanIt v1.3.8 workflow showing capture, result and sharing, file controls, and signature placement."></a>
 </p>
 
-## v1.3.7 update
+## v1.3.8 update
 
 The current stable release keeps the full Google scan editor with page previews,
 crop and rotate, and Google's filter gallery, then continues directly to the
@@ -45,10 +45,12 @@ before its first use; Actions report that state and can be retried afterward.
 Result pages now swipe horizontally and reveal the edge of the next page.
 Rescan, Sign / stamp, and Actions are compact accessible buttons, while File details groups
 PDF and image changes into compact Size, Format, and Location controls.
+Externally deleted PDF and image outputs are shown as Deleted and can be recreated
+directly with Save without reusing stale provider locations.
 After a full app restart, ScanIt opens a fresh scanner session instead of reopening
 the previously viewed Result; completed scans remain available from Recent.
 
-[Download ScanIt v1.3.7](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.7)
+[Download ScanIt v1.3.8](https://github.com/Majkey25/ScanIt/releases/tag/v1.3.8)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         applicationId = "com.majkeylab.scanit"
         minSdk = 33
         targetSdk = 36
-        versionCode = 21
-        versionName = "1.3.7"
+        versionCode = 22
+        versionName = "1.3.8"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/majkeylab/scanit/AppUi.kt
+++ b/app/src/main/java/com/majkeylab/scanit/AppUi.kt
@@ -866,6 +866,7 @@ private fun ResultScreen(
                         outputChangeInProgress = result.outputChangeInProgress,
                         onSaveNow = { showSaveDialog = true },
                         onSavePdfNow = { onSaveNow(SaveNowTarget.Pdf) },
+                        onSaveImagesNow = { onSaveNow(SaveNowTarget.Images) },
                         onChangePdfSize = { showPdfSizeDialog = true },
                         onChangePdfLocation = onChangePdfLocation,
                         onChangeImageSize = { showImageSizeDialog = true },
@@ -1678,6 +1679,7 @@ private fun FileDetails(
     outputChangeInProgress: Boolean,
     onSaveNow: () -> Unit,
     onSavePdfNow: () -> Unit,
+    onSaveImagesNow: () -> Unit,
     onChangePdfSize: () -> Unit,
     onChangePdfLocation: () -> Unit,
     onChangeImageSize: () -> Unit,
@@ -1712,7 +1714,7 @@ private fun FileDetails(
                 else -> R.string.file_saved
             },
         )
-    val imagesLocation = imageLocationLabel(scan)
+    val imagesLocation = if (scan.savedImagesDeleted) "" else imageLocationLabel(scan)
     val pdfDisplayName = scan.savedPdfDisplayName ?: scan.cached.pdf.name
     val pdfBaseName = normalizeOutputBaseName(pdfDisplayName)
     val imageBaseName =
@@ -1721,6 +1723,7 @@ private fun FileDetails(
     val imageDisplayName = scan.savedImages.firstOrNull()?.displayName ?: imageBaseName
     val imageStatus =
         when {
+            scan.savedImagesDeleted -> stringResource(R.string.file_deleted)
             scan.galleryPages.isEmpty() -> stringResource(R.string.file_temporary)
             scan.galleryPages.size == scan.cached.pages.size -> stringResource(R.string.file_saved)
             else ->
@@ -1890,9 +1893,16 @@ private fun FileDetails(
                         savedImageBytes(scan),
                     ),
             )
-            FileDetailRow(
+            FileDetailStatusRow(
                 label = stringResource(R.string.status),
                 value = imageStatus,
+                actionLabel = stringResource(R.string.save).takeIf { scan.savedImagesDeleted },
+                actionEnabled =
+                    scan.savedImagesDeleted &&
+                        SaveNowTarget.Images in saveTargets &&
+                        !saveInProgress &&
+                        !outputChangeInProgress,
+                onAction = onSaveImagesNow,
             )
             FileDetailRow(
                 label = stringResource(R.string.location),
@@ -2158,7 +2168,7 @@ private fun FileDetailStatusRow(
     onAction: () -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -2178,7 +2188,7 @@ private fun FileDetailStatusRow(
                 TextButton(
                     onClick = onAction,
                     enabled = actionEnabled,
-                    modifier = Modifier.heightIn(min = 40.dp),
+                    modifier = Modifier.height(40.dp),
                     contentPadding = PaddingValues(horizontal = 8.dp),
                 ) {
                     Text(actionLabel)

--- a/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
+++ b/app/src/main/java/com/majkeylab/scanit/DurableOutputDelete.kt
@@ -458,6 +458,35 @@ internal class ExactOutputDeleter(private val context: Context) {
             queryMediaOutput(reference.uri, MediaOutputCollection.Downloads, identity)
         }
 
+    fun queryImage(cached: CachedScan, reference: ImageOutputRef): ExactItemQuery =
+        providerQueryResult {
+            if (reference.page !in 1..cached.pages.size) {
+                return@providerQueryResult ExactItemQuery.IdentityMismatch
+            }
+            reference.outputFingerprint() ?: return@providerQueryResult ExactItemQuery.Failed
+            val mimeType = reference.mimeType?.takeIf { it in IMAGE_MIME_TYPES }
+                ?: return@providerQueryResult ExactItemQuery.IdentityMismatch
+            if (reference.treeUri != null) {
+                if (reference.ownerPackageName != null) {
+                    return@providerQueryResult ExactItemQuery.IdentityMismatch
+                }
+                return@providerQueryResult querySafOutput(
+                    uriValue = reference.uri,
+                    treeUriValue = reference.treeUri,
+                    displayName = reference.displayName,
+                    mimeType = mimeType,
+                )
+            }
+            val identity =
+                expectedMediaIdentity(
+                    reference.displayName,
+                    mimeType,
+                    reference.ownerPackageName,
+                    mimeType,
+                ) ?: return@providerQueryResult ExactItemQuery.IdentityMismatch
+            queryMediaOutput(reference.uri, MediaOutputCollection.Images, identity)
+        }
+
     fun deletePdf(reference: PdfOutputRef): OutputDeleteStatus =
         reference.outputFingerprint()?.let { fingerprint ->
             if (reference.treeUri != null) {
@@ -876,7 +905,9 @@ internal class ExactOutputDeleter(private val context: Context) {
     ): ExactItemQuery {
         val exactDisplayName = displayName ?: return ExactItemQuery.IdentityMismatch
         val exactMimeType = mimeType ?: return ExactItemQuery.IdentityMismatch
-        if (exactMimeType != PDF_MIME_TYPE) return ExactItemQuery.IdentityMismatch
+        if (exactMimeType != PDF_MIME_TYPE && exactMimeType !in IMAGE_MIME_TYPES) {
+            return ExactItemQuery.IdentityMismatch
+        }
         val tree = exactContentUri(treeUriValue) ?: return ExactItemQuery.IdentityMismatch
         val document = exactContentUri(uriValue) ?: return ExactItemQuery.IdentityMismatch
         if (tree.authority != document.authority) return ExactItemQuery.IdentityMismatch

--- a/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanModels.kt
@@ -417,6 +417,21 @@ internal fun visiblePdfOutput(
         else -> VisiblePdfOutput(reference, false)
     }
 
+internal enum class ImageOutputPresence {
+    Present,
+    Deleted,
+    Uncertain,
+}
+
+internal fun imageOutputPresence(results: List<ExactItemQuery>): ImageOutputPresence =
+    when {
+        results.isNotEmpty() && results.all { it == ExactItemQuery.Exact } ->
+            ImageOutputPresence.Present
+        results.isNotEmpty() && results.all { it == ExactItemQuery.Absent } ->
+            ImageOutputPresence.Deleted
+        else -> ImageOutputPresence.Uncertain
+    }
+
 internal fun imageOutputLocationLabel(locations: List<String>): String? {
     val unique = locations.distinct()
     if (unique.isEmpty()) return null
@@ -758,6 +773,7 @@ internal data class SavedScan(
     val savedPdfDisplayName: String? = null,
     val savedPdfLocation: String? = null,
     val savedPdfDeleted: Boolean = false,
+    val savedImagesDeleted: Boolean = false,
     val warnings: List<UiMessage> = emptyList(),
     val outputMetadataValid: Boolean = false,
     val savedPdfDeleteVerified: Boolean = false,

--- a/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
+++ b/app/src/main/java/com/majkeylab/scanit/ScanStorage.kt
@@ -2909,7 +2909,23 @@ internal class ScanStorage(
                     initial,
                     cached.pages.size,
                 )?.let { existing ->
-                    return@withLock existing.map { it.uri.toUri() }
+                    when (
+                        imageOutputPresence(
+                            existing.map { outputDeleter.queryImage(cached, it) },
+                        )
+                    ) {
+                        ImageOutputPresence.Present ->
+                            return@withLock existing.map { it.uri.toUri() }
+                        ImageOutputPresence.Deleted ->
+                            rewriteCachedOutputMetadata(cached) { metadata ->
+                                if (metadata.images != existing) {
+                                    throw IOException("Saved image authority changed")
+                                }
+                                metadata.copy(images = emptyList())
+                            }
+                        ImageOutputPresence.Uncertain ->
+                            throw IOException("Saved image identity could not be verified")
+                    }
                 }
                 cached.pages.forEachIndexed { index, source ->
                     val page = index + 1
@@ -3281,11 +3297,15 @@ internal class ScanStorage(
         val activePdf = metadata?.pdf?.takeUnless(PdfOutputRef::pending)
         val visiblePdf = visiblePdfOutput(activePdf, outputDeleter::queryPdf)
         val activeImages = metadata?.images?.filterNot(ImageOutputRef::pending).orEmpty()
+        val imagePresence =
+            imageOutputPresence(activeImages.map { outputDeleter.queryImage(cached, it) })
+        val visibleImages =
+            if (imagePresence == ImageOutputPresence.Deleted) emptyList() else activeImages
         val exact = metadata?.takeIf { it.hasCompleteExactDeleteInventory(context.packageName) }
         return SavedScan(
             cached = cached,
             savedImages =
-                activeImages.map { image ->
+                visibleImages.map { image ->
                     SavedImageOutput(
                         page = image.page,
                         uri = image.uri.toUri(),
@@ -3322,6 +3342,7 @@ internal class ScanStorage(
                     )
                 },
             savedPdfDeleted = visiblePdf.deleted,
+            savedImagesDeleted = imagePresence == ImageOutputPresence.Deleted,
             warnings =
                 (warnings + listOfNotNull(pdfSizeTargetWarning(cached.pdfSizeTarget, cached.pdf.length())))
                     .distinct(),
@@ -3329,8 +3350,8 @@ internal class ScanStorage(
             savedPdfDeleteVerified =
                 !mutationBlocked && exact?.pdf == visiblePdf.reference && visiblePdf.reference != null,
             savedImagesDeleteVerified =
-                !mutationBlocked && activeImages.isNotEmpty() &&
-                    exact?.images == activeImages,
+                !mutationBlocked && visibleImages.isNotEmpty() &&
+                    exact?.images == visibleImages,
             unknownOutputCreateAcknowledgement = unknownOutputCreateAcknowledgement,
         )
     }

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -205,6 +205,26 @@ class PureLogicTest {
     }
 
     @Test
+    fun imagesAreDeletedOnlyWhenEverySavedPageIsConfirmedAbsent() {
+        assertEquals(
+            ImageOutputPresence.Present,
+            imageOutputPresence(listOf(ExactItemQuery.Exact, ExactItemQuery.Exact)),
+        )
+        assertEquals(
+            ImageOutputPresence.Deleted,
+            imageOutputPresence(listOf(ExactItemQuery.Absent, ExactItemQuery.Absent)),
+        )
+        listOf(
+            emptyList(),
+            listOf(ExactItemQuery.Exact, ExactItemQuery.Absent),
+            listOf(ExactItemQuery.IdentityMismatch),
+            listOf(ExactItemQuery.Failed),
+        ).forEach { results ->
+            assertEquals(ImageOutputPresence.Uncertain, imageOutputPresence(results))
+        }
+    }
+
+    @Test
     fun outputNamesRejectPathsControlsAndEmptyValues() {
         listOf(
             "",

--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -19,8 +19,8 @@ submitted declarations:
 |---|---|
 | App name | `ScanIt` |
 | Package | `com.majkeylab.scanit` |
-| Version code | `21` |
-| Version name | `1.3.7` |
+| Version code | `22` |
+| Version name | `1.3.8` |
 | Default language | English (United States) |
 | App or game | App |
 | Category | Productivity |
@@ -126,29 +126,29 @@ the Play developer account.
 >
 > Skener používá Google ML Kit Document Scanner a vyžaduje služby Google Play. Služby Google Play mohou před prvním použitím stáhnout modul skeneru nebo rozpoznávání a zpracovávat omezené diagnostické a provozní údaje.
 
-## Release notes — version 21 / 1.3.7
+## Release notes — version 22 / 1.3.8
 
 Each block is below Google Play's 500-character per-language limit.
 
 ### English (United States)
 
-> File details now shows only the containing folder in Location. The PDF or image name stays in its separate editable field, keeping saved-file information clear and compact.
+> File details now keeps Deleted rows aligned and detects saved images removed outside the app. Missing PDFs and images each offer Save to recreate the file safely.
 
 ### Čeština
 
-> Detaily souboru nyní v poli Umístění ukazují jen cílovou složku. Název PDF nebo obrázku zůstává v samostatném upravitelném poli, takže jsou informace přehlednější.
+> Detaily souboru nyní drží řádky Smazáno zarovnané a rozpoznají obrázky odstraněné mimo aplikaci. Chybějící PDF i obrázky lze bezpečně znovu vytvořit tlačítkem Uložit.
 
 ### Deutsch
 
-> Die Dateidetails zeigen unter Speicherort nur noch den Zielordner. Der Name der PDF- oder Bilddatei bleibt im separaten bearbeitbaren Feld, sodass die Ansicht kompakt bleibt.
+> Die Dateidetails halten Gelöscht-Zeilen ausgerichtet und erkennen extern entfernte Bilder. Fehlende PDFs und Bilder können jeweils sicher mit Speichern neu erstellt werden.
 
 ### Español
 
-> Detalles del archivo ahora muestra solo la carpeta de destino en Ubicación. El nombre del PDF o de la imagen permanece en su campo editable separado para una vista más clara.
+> Detalles del archivo mantiene alineadas las filas Eliminado y detecta imágenes borradas fuera de la app. PDF e imágenes ausentes se pueden recrear de forma segura con Guardar.
 
 ### 简体中文
 
-> 文件详情中的位置现在仅显示目标文件夹。PDF 或图片名称仍保留在单独的可编辑字段中，使保存信息更清晰、更紧凑。
+> 文件详情现在会保持“已删除”状态行对齐，并检测在应用外删除的图片。缺失的 PDF 和图片都可通过“保存”安全地重新创建。
 
 The listing describes current implemented public behavior only. It does not
 claim certificate-backed signatures, guaranteed PDF compression, cloud
@@ -326,7 +326,7 @@ action, donation, unfinished feature, or device mockup in the feature graphic.
 
 ## Submission checklist
 
-- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 21, version `1.3.7`; verify after the final release build.
+- [ ] Signed AAB is exactly `com.majkeylab.scanit`, version code 22, version `1.3.8`; verify after the final release build.
 - [x] R8 mapping from the exact build is retained. The only native library is a prebuilt dependency without a separate symbol payload; no fake symbols are uploaded.
 - [x] Public artifact contains no public cloud-processing code or app-owned `INTERNET` permission.
 - [x] Complete third-party license text and applicable notices are packaged with the APK/AAB distribution and verified in the exact artifact.

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $false
 $isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
 $androidNamespace = "http://schemas.android.com/apk/res/android"
-$expectedVersionCode = "21"
+$expectedVersionCode = "22"
 $expectedMinSdk = "33"
 $expectedTargetSdk = "36"
 $publicFlavor = $Flavor -ne "internal"
@@ -99,15 +99,15 @@ Assert-ReleasePolicyConfiguration
 switch ($Flavor) {
     "internal" {
         $expectedPackage = "com.majkeylab.scanit.internal"
-        $expectedVersionName = "1.3.7-internal"
+        $expectedVersionName = "1.3.8-internal"
     }
     "play" {
         $expectedPackage = "com.majkeylab.scanit"
-        $expectedVersionName = "1.3.7"
+        $expectedVersionName = "1.3.8"
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionName = "1.3.7"
+        $expectedVersionName = "1.3.8"
     }
 }
 


### PR DESCRIPTION
## Summary
- keep Deleted status rows aligned
- detect externally deleted saved images
- recreate missing PDFs/images without stale provider URIs
- prepare version 1.3.8 (code 22)

## Verification
- full Internal/Play/GitHub Gradle gate: PASS (153 tasks)
- signed tools/build.ps1 gate: PASS (161 tasks)
- emulator: PDF + 3 images externally deleted, detected, re-saved to new exact MediaStore URIs
- no crash or ANR