### PR TITLE
Release full open-source SeliaScan 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes are documented here.
 
+## [1.7.0] - 2026-08-30
+
+### Changed
+
+- Published the complete SeliaScan feature set as the stable GitHub edition.
+- Kept every scan, signing, file-editing, cleanup, OCR, redaction, and Document Action feature unlocked.
+- Removed advertising, consent, Billing, Premium, paywalls, locks, and monetization from the source and release artifacts.
+- Licensed the public source under the MIT License; Buy Me a Coffee remains optional and unlocks nothing.
+
+### Distribution
+
+- Versioned the `github` flavor as `1.7.0` code 39 for Android 10 and newer.
+- Kept the separately maintained Google Play ads and Premium build unchanged.
+
 ## [1.6.0] - 2026-08-26
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,48 +1,21 @@
-SeliaScan (formerly ScanIt) Source-Visible Proprietary License
+MIT License
 
-Copyright (c) 2026 Majkey25. All rights reserved.
+Copyright (c) 2026 Majkey25
 
-1. Scope
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This license applies to the SeliaScan and ScanIt source code and other original
-material included in the repository revision that introduces this license, and
-to original material published later with this license. It does not
-apply to third-party material. Earlier copies already distributed under the MIT
-License retain that license as explained in section 4.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Official binary use
-
-You may download, install, and use an unmodified official SeliaScan or ScanIt binary release
-for any lawful purpose. An official binary release is one distributed by
-Majkey25 through the existing GitHub Releases page, Google Play, or another
-channel explicitly identified by Majkey25.
-
-3. Source visibility
-
-The source repository is public for inspection. Except for the official binary
-permission above, no permission is granted to copy, modify, build, distribute,
-sublicense, sell, or create derivative works from material covered by this
-license. GitHub features such as viewing and platform-provided forking remain
-subject to GitHub's terms. Rights required by applicable law are not restricted.
-Additional permission requires prior written authorization from Majkey25.
-
-4. Historical MIT grants
-
-Material previously distributed under the ScanIt name and MIT License remains available
-under that license for those historical copies. This license does not revoke or
-limit any earlier MIT grant. See HISTORICAL_MIT_RELEASES.md.
-
-5. Third-party material and names
-
-Third-party software, services, and marks remain subject to their own terms.
-See THIRD_PARTY_NOTICES.md. This license grants no right to use the SeliaScan,
-ScanIt, or Majkey25 names, logos, or other brand features except to identify an unmodified
-official binary accurately.
-
-6. No warranty
-
-THE SOFTWARE AND MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE, AND NON-INFRINGEMENT. TO THE MAXIMUM EXTENT PERMITTED BY LAW,
-THE COPYRIGHT HOLDER IS NOT LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY
-ARISING FROM THE SOFTWARE OR ITS USE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@ SeliaScan is the new product name for ScanIt. The Android package and existing r
   <a href="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml"><img alt="Android CI" src="https://github.com/Majkey25/ScanIt/actions/workflows/android-ci.yml/badge.svg"></a>
   <a href="https://github.com/Majkey25/ScanIt/releases/latest"><img alt="Latest stable release" src="https://img.shields.io/github/v/release/Majkey25/ScanIt"></a>
   <img alt="Android 10+" src="https://img.shields.io/badge/Android-10%2B-111111">
-  <a href="LICENSE"><img alt="Source-visible proprietary license" src="https://img.shields.io/badge/License-Proprietary-111111"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-111111"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.6.0"><img src="docs/images/scanit-current-overview.png" width="100%" alt="SeliaScan workflow showing capture, result and sharing, file controls, and signature placement."></a>
+  <a href="https://github.com/Majkey25/ScanIt/releases/tag/v1.7.0"><img src="docs/images/scanit-current-overview.png" width="100%" alt="SeliaScan workflow showing capture, result and sharing, file controls, and signature placement."></a>
 </p>
 
-## v1.6.0 update
+## v1.7.0 update
+
+The stable GitHub edition is fully open source under the MIT License. It has no
+ads, consent flow, Billing, Premium tier, paywall, or feature locks. Every scan,
+signing, file-editing, cleanup, OCR, redaction, and Document Action feature is
+available immediately. Buy Me a Coffee remains an optional donation and does
+not change app functionality.
 
 Manual redaction now defaults to a professional straight-line tool and keeps the
 freehand brush as an option. Both share adjustable thickness, undo, redo, clear,
@@ -72,7 +78,7 @@ directly with Save without reusing stale provider locations.
 After a full app restart, SeliaScan opens a fresh scanner session instead of reopening
 the previously viewed Result; completed scans remain available from Recent.
 
-[Download SeliaScan v1.6.0](https://github.com/Majkey25/ScanIt/releases/tag/v1.6.0)
+[Download SeliaScan v1.7.0](https://github.com/Majkey25/ScanIt/releases/tag/v1.7.0)
 or read the [full changelog](CHANGELOG.md).
 
 <p align="center">
@@ -134,7 +140,7 @@ source, release artifacts, and real-device workflows.
 
 Download the
 [latest stable GitHub APK](https://github.com/Majkey25/ScanIt/releases/latest/download/app-github-release.apk).
-SeliaScan v1.6.0 supports Android 10 and newer.
+SeliaScan v1.7.0 supports Android 10 and newer.
 
 Google Play services may download the scanner and recognition modules before
 their first use. This repository builds only the full no-ads GitHub edition and

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,8 +68,8 @@ android {
         create("github") {
             dimension = "distribution"
             applicationIdSuffix = ".github"
-            versionCode = 36
-            versionName = "1.6.0"
+            versionCode = 39
+            versionName = "1.7.0"
         }
         create("internal") {
             dimension = "distribution"

--- a/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
+++ b/app/src/test/java/com/majkeylab/scanit/PureLogicTest.kt
@@ -761,10 +761,10 @@ class PureLogicTest {
         val build = File(repository, "app/build.gradle.kts").readText()
         val verifier = File(repository, "tools/verify-release.ps1").readText()
 
-        assertTrue(build.contains("versionCode = 36"))
-        assertTrue(build.contains("versionName = \"1.6.0\""))
-        assertTrue(verifier.contains("\$expectedVersionCode = \"36\""))
-        assertTrue(verifier.contains("\$expectedVersionName = \"1.6.0\""))
+        assertTrue(build.contains("versionCode = 39"))
+        assertTrue(build.contains("versionName = \"1.7.0\""))
+        assertTrue(verifier.contains("\$expectedVersionCode = \"39\""))
+        assertTrue(verifier.contains("\$expectedVersionName = \"1.7.0\""))
         assertFalse(build.contains("create(\"beta\")"))
         assertFalse(build.contains("create(\"play\")"))
     }

--- a/tools/verify-release.ps1
+++ b/tools/verify-release.ps1
@@ -129,8 +129,8 @@ switch ($Flavor) {
     }
     "github" {
         $expectedPackage = "com.majkeylab.scanit.github"
-        $expectedVersionCode = "36"
-        $expectedVersionName = "1.6.0"
+        $expectedVersionCode = "39"
+        $expectedVersionName = "1.7.0"
     }
     "beta" {
         $expectedPackage = "com.majkeylab.scanit"


### PR DESCRIPTION
Publishes the stable GitHub edition with all features unlocked, no ads, no Billing or Premium, and the MIT License. Google Play remains unchanged. Local release gate passed: 110 Gradle tasks, unit tests, lint, signed APK/AAB, and artifact verification.