### PR TITLE
Clarify external backups and advertising disclosures

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -38,8 +38,11 @@ and device transfer are disabled for app settings and private data.
 
 Sharing, printing, email, external links, and selected storage providers receive
 content only after a user action and apply their own privacy terms.
+Cloud-backed folders and Gallery or backup services configured by the user may
+upload saved files. SeliaScan's disabled Android backup does not disable those
+services or delete external copies.
 
 For privacy questions, email [majkeylab@gmail.com](mailto:majkeylab@gmail.com).
 Do not send private documents or credentials.
 
-Last updated: 2026-09-05.
+Last updated: 2026-09-06.

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -23,7 +23,7 @@
 
   <main id="main" class="policy">
     <h1>Privacy Policy</h1>
-    <p class="updated">Effective and last updated: 2026-09-05</p>
+    <p class="updated">Effective and last updated: 2026-09-06</p>
 
     <p>This policy describes the public SeliaScan Android app and this SeliaScan website. Contact the maintainer at <a href="mailto:majkeylab@gmail.com">majkeylab@gmail.com</a> with privacy questions. Do not email private documents or credentials.</p>
 
@@ -41,6 +41,7 @@
     <p>According to your settings and actions, SeliaScan can save images to Gallery or a folder selected through Android's folder picker and PDFs to Downloads or a selected folder. They remain until you delete them through Recent scans, Gallery, Files, or the selected-folder provider. Selecting a sharing app never deletes the saved copy. Uninstalling SeliaScan does not remove saved files outside app-private storage.</p>
 
     <h3>Settings, backup, and deletion</h3>
+    <p>A cloud-backed folder provider, or a Gallery or backup service you configured, may upload saved files under its own privacy terms. Disabling SeliaScan's Android backup does not disable those services or delete their external copies. Manage and delete those copies with the selected provider.</p>
     <p>Settings are stored locally in app-private storage. Android backup and device-to-device transfer are disabled for SeliaScan app data. Uninstalling the app removes its private settings and cache. It does not remove files saved outside the app-private area.</p>
 
     <h2>Google ML Kit Document Scanner</h2>
@@ -61,7 +62,7 @@
 
     <p>Google states that its current Mobile Ads SDK automatically collects and shares IP address, product interactions such as app launches, taps, and video views, diagnostic information such as launch time, hangs, and energy use, and device or account identifiers including Android advertising ID and app set ID. Google uses this information for advertising, analytics, and fraud prevention and encrypts it in transit using TLS. See Google's <a href="https://developers.google.com/admob/android/next-gen/privacy/play-data-disclosure">GMA Next-Gen data disclosure</a> and <a href="https://policies.google.com/privacy">Privacy Policy</a>.</p>
 
-    <p>SeliaScan does not intentionally pass scanned pages, OCR text, generated PDFs, saved images, email defaults, or selected recipients to the advertising SDK. Advertising begins only after a completed scan reaches Result. The stable scanning, cleanup, OCR, saving, and sharing code continues to process document content locally.</p>
+    <p>SeliaScan does not pass scanned pages, OCR text, generated PDFs, saved images, email defaults, or selected recipients to the advertising SDK. When ads are enabled, advertising may initialize or load on eligible screens, including Result and Recent scans, after the applicable consent checks. Scanning, cleanup, OCR, saving, and sharing continue to process document content locally.</p>
 
     <h3>Premium purchases</h3>
     <p>Google Play Billing returns the monthly subscription or lifetime Premium product identifier, purchase state, acknowledgement state, and purchase token needed to buy or restore Premium for the current Google Play account. SeliaScan does not receive payment-card details, does not log purchase tokens, and does not persist a local Premium entitlement. Either confirmed product unlocks Document Actions and removes ads. The monthly subscription renews until canceled in Google Play. A pending purchase grants nothing until Google Play confirms it.</p>
@@ -77,7 +78,7 @@
 
     <p>The site is hosted by GitHub Pages. GitHub states that it logs and stores visitors' IP addresses for security and may process other service data under the <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub General Privacy Statement</a>. SeliaScan adds no code that exposes those hosting logs to the maintainer.</p>
 
-    <p>External links, including GitHub, email, and Buy Me a Coffee, are opened only when you select them. Those services apply their own privacy terms. SeliaScan does not receive payment-card or billing details from Buy Me a Coffee.</p>
+    <p>External links, including GitHub, email, and Buy Me a Coffee, are opened only when you select them. Those services apply their own privacy terms. The Android app does not receive payment-card details from Buy Me a Coffee and a contribution does not unlock features. The maintainer may receive supporter information provided by that service; the support-handling section above applies to information received directly by the maintainer.</p>
 
     <h2>Children</h2>
     <p>SeliaScan is intended for an adult document workflow and is not directed to children under 18. It has no account or social features.</p>


### PR DESCRIPTION
Docs-only accuracy fixes. Explain cloud-backed folder/Gallery uploads and external-copy deletion, acknowledge eligible Result/Recent ad initialization instead of promising ads start only after a completed scan, and distinguish Android app payment access from supporter information the maintainer may receive. No app binary, SDK, permission, price or entitlement change. Reviewed against existing storage/ad flows; live Pages verification follows merge. This is a technical disclosure correction, not universal legal certification.