### PR TITLE
docs: remove stale edition version

### DIFF
--- a/docs/play-store/PLAY_CONSOLE.md
+++ b/docs/play-store/PLAY_CONSOLE.md
@@ -3,7 +3,6 @@
 This public checkout builds the fully unlocked, no-ads SeliaScan GitHub edition:
 
 - package: `com.majkeylab.scanit.github`
-- version: `1.8.0` (code 40)
 - license: MIT
 - advertising, consent, Billing, Premium, paywalls, and feature locks: absent
 


### PR DESCRIPTION
Removes a duplicated 1.8.0 version from the Play-boundary document; current version is already maintained in app/build.gradle.kts and README. One-line documentation-only cleanup, no app or release artifact change.